### PR TITLE
Remove sprite resource and region config options

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -3,22 +3,7 @@ title: Configuration Reference
 description: All configuration options for Sprites
 ---
 
-This page documents all configuration options available for Sprites, including resource allocation, environment settings, and client configuration.
-
-## Sprite Configuration
-
-### Resource Options
-
-Sprites currently use a fixed resource configuration set by the service:
-
-| Resource | Value |
-|----------|-------|
-| CPUs | 8 vCPUs |
-| RAM | 8192 MB |
-| Storage | 100 GB |
-
-The region is chosen by the API based on its deployment region (`FLY_REGION`), with a fallback of `iad`.
-These values are not configurable via the CLI/SDK/API yet. (SDK config fields are accepted but ignored by the API.)
+This page documents all configuration options available for Sprites, including environment settings and client configuration.
 
 ## URL Settings
 

--- a/src/content/docs/sdks/go.mdx
+++ b/src/content/docs/sdks/go.mdx
@@ -83,15 +83,6 @@ token, err := sprites.CreateToken(ctx,
 ```go
 // Simple creation
 sprite, err := client.CreateSprite(ctx, "my-sprite", nil)
-
-// With configuration
-sprite, err := client.CreateSprite(ctx, "my-sprite", &sprites.SpriteConfig{
-    CPUs:      2,
-    RamMB:     8192,
-    StorageGB: 200,
-    Region:    "ord",
-})
-// Note: config fields are accepted but currently ignored by the API.
 ```
 
 ### Getting Sprites

--- a/src/content/docs/sdks/javascript.mdx
+++ b/src/content/docs/sdks/javascript.mdx
@@ -72,15 +72,6 @@ const token = await SpritesClient.createToken(
 ```javascript
 // Simple creation
 const sprite = await client.createSprite('my-sprite');
-
-// With configuration
-const sprite = await client.createSprite('my-sprite', {
-  cpus: 2,
-  ramMB: 8192,
-  storageGB: 200,
-  region: 'ord',
-});
-// Note: config fields are accepted but currently ignored by the API.
 ```
 
 ### Getting Sprites


### PR DESCRIPTION
Per Issue #4 -- remove mentions of resource and region config, which don't apply to Sprites