### PR TITLE
Fix 404 page routing and cleanup

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,12 +24,13 @@ RUN pnpm run build
 # Final stage - minimal nginx
 FROM nginx:alpine
 
-# SPA routing + caching for static assets
+# Static site routing + caching for static assets
 RUN printf 'server {\n\
     listen 80;\n\
     root /usr/share/nginx/html;\n\
+    error_page 404 /404.html;\n\
     location / {\n\
-        try_files $uri $uri/ $uri.html /index.html;\n\
+        try_files $uri $uri/ $uri.html =404;\n\
     }\n\
     location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {\n\
         expires 1y;\n\

--- a/src/pages/404.astro
+++ b/src/pages/404.astro
@@ -136,14 +136,6 @@ import '@/styles/custom.css';
         user-select: none;
       }
 
-      .command {
-        color: oklch(0.9 0.01 106.423);
-      }
-
-      .path {
-        color: oklch(0.768 0.233 130.85);
-      }
-
       .error-line {
         display: flex;
         align-items: baseline;
@@ -284,11 +276,6 @@ import '@/styles/custom.css';
           </div>
         </div>
         <div class="terminal-body">
-          <div class="line">
-            <span class="prompt">$ </span>
-            <span class="command">sprite exec</span>
-            <span class="path"> {Astro.url.pathname}</span>
-          </div>
           <div class="error-line">
             <span class="error-code">404</span>
             <span class="error-msg">This sprite escaped its sandbox</span>


### PR DESCRIPTION
## Summary

- **Fix nginx routing**: Custom 404 page now shows for all missing routes (was incorrectly falling back to index.html with 200 status)
- **Clean up 404.astro**: Removed unused CSS, improved mobile responsiveness and accessibility

## Changes

### Nginx (Dockerfile)
```diff
- try_files $uri $uri/ $uri.html /index.html;
+ error_page 404 /404.html;
+ try_files $uri $uri/ $uri.html =404;
```

This returns proper 404 status codes for SEO instead of serving the homepage with 200.

### 404.astro
- Removed unused CSS classes (`.terminal-title`, `.command`, `.path`, `.comment`)
- Added `max-width: none` to fix PixelBlast background cutoff
- Added `flex-wrap: wrap` for mobile button layout
- Fixed bidirectional fade transition on background
- Added `aria-label` to search button

## Test plan
- [ ] Visit `/non-existent-route` - should show 404 page with 404 status
- [ ] Visit `/404` directly - should still work
- [ ] All existing routes should work normally
- [ ] 404 page background should fill full viewport width

🤖 Generated with [Claude Code](https://claude.com/claude-code)