### PR TITLE
Change markdown export from .md to .txt extension

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,10 @@ RUN printf 'server {\n\
     location / {\n\
         try_files $uri $uri/ $uri.html =404;\n\
     }\n\
+    location ~* \\.md$ {\n\
+        types { text/plain md; }\n\
+        add_header Content-Disposition "inline";\n\
+    }\n\
     location ~* \\.(js|css|png|jpg|jpeg|gif|ico|svg|woff|woff2)$ {\n\
         expires 1y;\n\
         add_header Cache-Control "public, immutable";\n\

--- a/src/components/react/CopyPageButton.tsx
+++ b/src/components/react/CopyPageButton.tsx
@@ -80,8 +80,11 @@ export function CopyPageButton({
   };
 
   const handleViewMarkdown = () => {
-    const url = pageUrl.endsWith('/') ? pageUrl.slice(0, -1) : pageUrl;
-    window.open(`${url}.md`, '_blank');
+    const url = new URL(pageUrl);
+    const path = url.pathname.replace(/\/$/, '');
+    // Root path links to /index.md, otherwise append .md
+    const mdPath = path === '' ? '/index.md' : `${path}.md`;
+    window.open(`${url.origin}${mdPath}`, '_blank');
   };
 
   return (

--- a/src/pages/[...slug].md.ts
+++ b/src/pages/[...slug].md.ts
@@ -6,7 +6,7 @@ export const prerender = true;
 export const getStaticPaths: GetStaticPaths = async () => {
   const docs = await getCollection('docs');
   return docs.map((doc) => ({
-    params: { slug: doc.id === 'index' ? undefined : doc.id },
+    params: { slug: doc.id },
     props: { doc },
   }));
 };


### PR DESCRIPTION
## Summary
- Configure nginx to serve `.md` files as `text/plain` with `Content-Disposition: inline`
- Fix root URL handling: homepage now links to `/index.md` instead of broken `https://docs.sprites.dev.md`
- Generate `index.md` for the homepage

## Why
The `.md` extension was causing browsers to download instead of display inline. This was because nginx serves static files with default MIME types. Adding explicit nginx config fixes this while keeping the semantic `.md` extension (like Mintlify/PlanetScale does).

## Test plan
- [x] Click "View as Markdown" on the homepage → should open `/index.md` inline
- [x] Click "View as Markdown" on `/quickstart/` → should open `/quickstart.md` inline
- [x] Verify `.md` files display as plain text, not downloaded

🤖 Generated with [Claude Code](https://claude.com/claude-code)