### PR TITLE
Convert Astro config to TypeScript

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -1,5 +1,3 @@
-// @ts-check
-
 import react from '@astrojs/react';
 import sitemap from '@astrojs/sitemap';
 import starlight from '@astrojs/starlight';


### PR DESCRIPTION
## Summary

- Rename `astro.config.mjs` to `astro.config.ts` for full type inference
- Remove the `// @ts-check` workaround in favor of native TypeScript
- Provides better IDE autocomplete and catches config errors at build time

## Test plan

- [x] Build passes (`pnpm build`)
- [ ] Dev server works (`pnpm dev`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)