### PR TITLE
Default to dark theme for new visitors

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -141,6 +141,7 @@ export default defineConfig({
         Header: './src/components/Header.astro',
         Search: './src/components/Search.astro',
         ThemeSelect: './src/components/ThemeSelect.astro',
+        ThemeProvider: './src/components/ThemeProvider.astro',
         PageTitle: './src/components/PageTitle.astro',
         SiteTitle: './src/components/SiteTitle.astro',
         Pagination: './src/components/Pagination.astro',

--- a/src/components/ThemeProvider.astro
+++ b/src/components/ThemeProvider.astro
@@ -1,0 +1,31 @@
+---
+// Custom ThemeProvider that defaults to dark instead of system preference
+---
+
+{/* This is intentionally inlined to avoid FOUC. */}
+<script is:inline>
+	window.StarlightThemeProvider = (() => {
+		const storedTheme =
+			typeof localStorage !== 'undefined' && localStorage.getItem('starlight-theme');
+		// Default to dark when no stored preference (instead of system preference)
+		const theme = storedTheme || 'dark';
+		document.documentElement.dataset.theme = theme === 'light' ? 'light' : 'dark';
+		return {
+			updatePickers(theme = storedTheme || 'auto') {
+				document.querySelectorAll('starlight-theme-select').forEach((picker) => {
+					const select = picker.querySelector('select');
+					if (select) select.value = theme;
+					/** @type {HTMLTemplateElement | null} */
+					const tmpl = document.querySelector(`#theme-icons`);
+					const newIcon = tmpl && tmpl.content.querySelector('.' + theme);
+					if (newIcon) {
+						const oldIcon = picker.querySelector('svg.label-icon');
+						if (oldIcon) {
+							oldIcon.replaceChildren(...newIcon.cloneNode(true).childNodes);
+						}
+					}
+				});
+			},
+		};
+	})();
+</script>

--- a/src/components/react/ThemeSwitcher.tsx
+++ b/src/components/react/ThemeSwitcher.tsx
@@ -22,12 +22,12 @@ const themes = [
 function getTheme(): Theme {
   if (typeof localStorage !== 'undefined') {
     const stored = localStorage.getItem('starlight-theme');
-    if (stored === 'light' || stored === 'dark') {
-      return stored;
+    if (stored === 'light' || stored === 'dark' || stored === '') {
+      // Starlight stores empty string for 'auto'
+      return stored === '' ? 'auto' : stored;
     }
-    // Starlight stores empty string for 'auto'
   }
-  return 'auto';
+  return 'dark';
 }
 
 function setTheme(theme: Theme) {


### PR DESCRIPTION
## Summary
- Override Starlight's ThemeProvider to default to dark theme when no `starlight-theme` is set in localStorage
- Previously, new visitors saw light or dark based on their system preference
- Now new visitors always see dark theme, but can still switch to light or system preference

## Test plan
- [x] Clear localStorage and visit the site in a browser with light system preference
- [x] Verify the page loads with dark theme
- [ ] Verify the theme switcher shows "Dark" as selected
- [ ] Switch to Light, refresh — should persist as light
- [ ] Switch to System, refresh — should follow system preference

🤖 Generated with [Claude Code](https://claude.com/claude-code)