### PR TITLE
change API section link to new API docs

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -71,7 +71,7 @@ export default defineConfig({
         },
         {
           label: 'API',
-          items: [{ label: 'REST API', slug: 'api/rest' }],
+          items: [{ label: 'Sprites API v1', link: 'https://sprites.dev/api' }],
         },
         {
           label: 'Reference',


### PR DESCRIPTION
- update link from temp static API reference to new generated API docs which are more up to date