### PR TITLE
Add output section styling for code blocks

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -67,6 +67,28 @@ const breadcrumbSchema = {
   const checkIcon = `<svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" class="check-icon"><path d="M5 12l5 5L20 7"/></svg>`;
 
   function initCodeBlocks() {
+    // Output section styling - merge ```output blocks with preceding code block
+    document.querySelectorAll('.expressive-code').forEach((block) => {
+      if (block.dataset.outputProcessed) return;
+      block.dataset.outputProcessed = 'true';
+
+      // Check if this is an output block (language="output")
+      const pre = block.querySelector('pre');
+      if (!pre || pre.dataset.language !== 'output') return;
+
+      // Find the preceding code block
+      let prevSibling = block.previousElementSibling;
+      while (prevSibling && !prevSibling.classList.contains('expressive-code')) {
+        prevSibling = prevSibling.previousElementSibling;
+      }
+
+      if (!prevSibling) return;
+
+      // Mark this as an output block and hide its frame chrome
+      block.classList.add('is-output-block');
+      prevSibling.classList.add('has-output-block');
+    });
+
     // Custom copy buttons
     document.querySelectorAll('.expressive-code .copy button').forEach((button) => {
       if (button.dataset.customized) return;

--- a/src/content/docs/concepts/checkpoints.mdx
+++ b/src/content/docs/concepts/checkpoints.mdx
@@ -32,8 +32,10 @@ Checkpoints do **not** capture:
 ```bash
 # Create a checkpoint of the current sprite
 sprite checkpoint create
+```
 
-# Output: Checkpoint created: v1
+```output
+Checkpoint created: v1
 ```
 </TabItem>
 <TabItem label="Go">
@@ -90,8 +92,13 @@ sprite exec "npm install"
 
 # Save the clean state
 sprite checkpoint create
-# Output: Checkpoint created: v1
+```
 
+```output
+Checkpoint created: v1
+```
+
+```bash
 # Now experiment freely
 sprite exec "pip install experimental-package"
 sprite exec "rm -rf node_modules"  # Oops!
@@ -108,12 +115,13 @@ sprite restore v1
 ```bash
 # List all checkpoints for the current sprite
 sprite checkpoint list
+```
 
-# Output:
-# ID                             CREATED             COMMENT
-# ------------------------------ ------------------- ------------------------
-# v1                             2024-01-15 10:30:00 After npm install
-# v0                             2024-01-14 15:45:00 Base (clean) state
+```output
+ID                             CREATED             COMMENT
+------------------------------ ------------------- ------------------------
+v1                             2024-01-15 10:30:00 After npm install
+v0                             2024-01-14 15:45:00 Base (clean) state
 ```
 </TabItem>
 <TabItem label="Go">
@@ -149,12 +157,13 @@ Get details about a specific checkpoint:
 <TabItem label="CLI">
 ```bash
 sprite checkpoint info v1
+```
 
-# Output:
-# ID: v1
-# Created: 2024-01-15T10:30:00Z
-# Comment: After npm install
-# History: (none)
+```output
+ID: v1
+Created: 2024-01-15T10:30:00Z
+Comment: After npm install
+History: (none)
 ```
 </TabItem>
 <TabItem label="Go">
@@ -256,8 +265,10 @@ You can delete individual checkpoints by their ID. Deleted checkpoints cannot be
 ```bash
 # Delete a specific checkpoint
 sprite checkpoint delete v3
+```
 
-# Output: Deleted
+```output
+Deleted
 ```
 </TabItem>
 </Tabs>
@@ -341,8 +352,13 @@ AI coding agents can checkpoint their own work. Point your LLM at `/.sprite/llm.
 ```bash
 # Before risky operations
 sprite-env checkpoints create
-# Output: {"status": "complete", "id": "v4"}
+```
 
+```output
+{"status": "complete", "id": "v4"}
+```
+
+```bash
 # Try something risky...
 rm -rf node_modules && npm install
 
@@ -445,12 +461,20 @@ Checkpoints use sequential version IDs (v0, v1, v2, etc.). Add comments to descr
 ```bash
 # Create checkpoint with a descriptive comment
 sprite checkpoint create --comment "Clean Python 3.11 + Node 20 setup"
-# Output: Checkpoint created: v1
+```
 
+```output
+Checkpoint created: v1
+```
+
+```bash
 # List checkpoints to see comments
 sprite checkpoint list
-# ID    CREATED              COMMENT
-# v1    2024-01-15 10:30:00  Clean Python 3.11 + Node 20 setup
+```
+
+```output
+ID    CREATED              COMMENT
+v1    2024-01-15 10:30:00  Clean Python 3.11 + Node 20 setup
 ```
 </TabItem>
 <TabItem label="Go">

--- a/src/content/docs/concepts/networking.mdx
+++ b/src/content/docs/concepts/networking.mdx
@@ -14,7 +14,10 @@ Every Sprite has a unique URL for HTTPS access, for example:
 
 ```bash
 sprite url
-# Output: https://my-sprite-abc123.sprites.dev
+```
+
+```output
+https://my-sprite-abc123.sprites.dev
 ```
 
 If your code is listening on a port (say, 3000 or 8080), that URL routes traffic to it. This means you can:
@@ -113,8 +116,13 @@ sprite exec -detachable "python -m http.server 8080"
 
 # Get the URL
 sprite url
-# Output: https://my-sprite-abc123.sprites.dev
+```
 
+```output
+https://my-sprite-abc123.sprites.dev
+```
+
+```bash
 # Access via browser or curl (after making public)
 curl https://my-sprite-abc123.sprites.dev:8080/
 ```

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -92,7 +92,7 @@
 [data-theme='dark'] {
   --background: oklch(0.147 0.004 49.25);
   --foreground: oklch(0.985 0.001 106.423);
-  --card: oklch(0.216 0.006 56.043);
+  --card: var(--sl-color-gray-6);
   --card-foreground: oklch(0.985 0.001 106.423);
   --popover: oklch(0.216 0.006 56.043);
   --popover-foreground: oklch(0.985 0.001 106.423);
@@ -443,6 +443,46 @@ pre[data-bash-prompt] > code {
 
 .expressive-code .copy button.copied .check-icon path {
   stroke-dashoffset: 0;
+}
+
+/* Output block styling - for ```output code blocks */
+.expressive-code.has-output-block figure {
+  border-bottom-left-radius: 0;
+  border-bottom-right-radius: 0;
+  border-bottom: none;
+}
+
+.expressive-code.has-output-block figure pre {
+  border-bottom-left-radius: 0 !important;
+  border-bottom-right-radius: 0 !important;
+  border-bottom: none !important;
+}
+
+.expressive-code.is-output-block {
+  margin-top: 0 !important;
+}
+
+.expressive-code.is-output-block figure {
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  border-top: none;
+  position: relative;
+}
+
+.expressive-code.is-output-block figure pre {
+  border-top: 1px dashed var(--sl-color-gray-4);
+  border-top-left-radius: 0 !important;
+  border-top-right-radius: 0 !important;
+  background: oklch(0.18 0 0) !important;
+}
+
+.expressive-code.is-output-block .ec-line {
+  opacity: 0.7;
+}
+
+/* Hide copy button on output blocks */
+.expressive-code.is-output-block .copy {
+  display: none;
 }
 
 /* Button pop animation */


### PR DESCRIPTION
## Summary

- Introduces a new ` ```output ` code block syntax that visually merges with the preceding code block
- Output blocks appear connected to their parent code block with a dashed separator
- Slightly lighter background distinguishes output from commands
- Output text is dimmed (opacity 0.7) and copy button is hidden
- Updates card background to match search box styling

## Usage

~~~markdown
```bash
sprite url
```

```output
https://my-sprite-abc123.sprites.dev
```
~~~

## Test plan

- [x] Check networking page shows merged code/output blocks
- [x] Check checkpoints page shows merged code/output blocks  
- [x] Verify dashed separator appears between command and output
- [x] Verify output section has slightly lighter background
- [x] Verify copy button is hidden on output blocks

🤖 Generated with [Claude Code](https://claude.com/claude-code)