### PR TITLE
Update resource allocation section for clarity

### DIFF
--- a/src/content/docs/working-with-sprites.mdx
+++ b/src/content/docs/working-with-sprites.mdx
@@ -35,7 +35,7 @@ A Sprite is considered active if any of the following are true:
 
 Sprites currently run on machines with a fixed resource cap: 8 vCPUs, 8192 MB RAM, and 100 GB storage. These limits are not configurable yet. The SDK accepts config fields, but the API ignores them.
 
-Keep in mind, Sprites are not billed based on those limits. You are only charged for the resources your Sprite actually uses. The fixed config defines the **maximum** resources each Sprite can consume, not a flat rate.
+Keep in mind, Sprites are not billed based on those limits. You are only charged for the resources your Sprite actually uses. The fixed config defines the current **maximum** resources each Sprite can consume, not a flat rate.
 
 ### Working Directory
 


### PR DESCRIPTION
- 8 vCPUs, 8192 MB RAM, and 100 GB storage is the current maximum per Sprite
- billing is based on actual usage