### PR TITLE
Add Plausible analytics tracking

### DIFF
--- a/src/components/Head.astro
+++ b/src/components/Head.astro
@@ -53,6 +53,13 @@ const breadcrumbSchema = {
 <Default {...Astro.props}><slot /></Default>
 <Background />
 
+<!-- Privacy-friendly analytics by Plausible -->
+<script async src="https://plausible.io/js/pa-X9Qgz6h0EcKGLrtNH5b5V.js"></script>
+<script>
+  window.plausible=window.plausible||function(){(plausible.q=plausible.q||[]).push(arguments)},plausible.init=plausible.init||function(i){plausible.o=i||{}};
+  plausible.init()
+</script>
+
 <!-- Dynamic OG Image -->
 <meta property="og:image" content={ogImageUrl} />
 <meta name="twitter:image" content={ogImageUrl} />


### PR DESCRIPTION
## Summary
- Adds Plausible analytics to the documentation site via the custom `Head.astro` component
- Uses async loading to avoid blocking page rendering
- Privacy-friendly, cookie-free analytics

## Test plan
- [ ] Verify the Plausible script loads on pages (check Network tab)
- [ ] Confirm page views are tracked in Plausible dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)