### PR TITLE
Track search queries with Plausible analytics

### DIFF
--- a/src/components/react/SearchDialog.tsx
+++ b/src/components/react/SearchDialog.tsx
@@ -66,6 +66,10 @@ interface Pagefind {
 declare global {
   interface Window {
     pagefind?: Pagefind;
+    plausible?: (
+      event: string,
+      options?: { props?: Record<string, string | number> },
+    ) => void;
   }
 }
 
@@ -464,7 +468,11 @@ export const SearchDialog: React.FC<SearchDialogProps> = ({
         case 'Enter':
           e.preventDefault();
           if (selectableItems[selectedIndex]) {
-            window.location.href = selectableItems[selectedIndex].url;
+            const item = selectableItems[selectedIndex];
+            window.plausible?.('Search', {
+              props: { query, path: item.url },
+            });
+            window.location.href = item.url;
             onClose();
           }
           break;
@@ -477,7 +485,7 @@ export const SearchDialog: React.FC<SearchDialogProps> = ({
 
     window.addEventListener('keydown', handleKeyDown);
     return () => window.removeEventListener('keydown', handleKeyDown);
-  }, [isOpen, selectableItems, selectedIndex, onClose]);
+  }, [isOpen, selectableItems, selectedIndex, onClose, query]);
 
   // Scroll selected item into view
   useEffect(() => {
@@ -677,6 +685,9 @@ export const SearchDialog: React.FC<SearchDialogProps> = ({
                       delay={0.03}
                       onMouseEnter={() => setSelectedIndex(index)}
                       onClick={() => {
+                        window.plausible?.('Search', {
+                          props: { query, path: item.url },
+                        });
                         window.location.href = item.url;
                         onClose();
                       }}


### PR DESCRIPTION
## Summary
- Tracks search queries when users select a result (click or Enter)
- Sends `query` (search term) and `path` (selected result URL) to Plausible
- Only tracks meaningful searches - when a user actually navigates to a result

## Test plan
- [x] Search for a term and click a result - verify event appears in Plausible
- [x] Search and press Enter on a result - verify event appears in Plausible
- [ ] Type but don't select a result - verify no event is sent

🤖 Generated with [Claude Code](https://claude.com/claude-code)