### PR TITLE
Add page feedback component with Plausible tracking

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -53,3 +53,32 @@ Custom Starlight components in `src/components/` override defaults: `Head.astro`
 - Dark mode is default; light mode uses violet accent (hue 285), dark uses teal/green (hue ~145)
 - Tailwind v4 custom variant: `@custom-variant dark (&:is(.dark *, [data-theme="dark"] *))`
 - Tables are auto-styled via rehype plugin with `data-slot` attributes for CSS targeting
+
+### Starlight CSS Specificity
+
+Starlight's CSS can override Tailwind classes due to cascade layers. When Tailwind margin/padding classes don't work in React components, use inline styles instead:
+```tsx
+// Tailwind class may not apply
+<div className="mb-6">  // ❌ May be overridden
+
+// Inline style works
+<div style={{ marginBottom: '2.5rem' }}>  // ✅ Guaranteed
+```
+
+### Starlight Layout Structure
+
+Key spacing sources in Starlight's default layout:
+- `footer.sl-flex` has `gap: 1.5rem` and `flex-direction: column`
+- `footer .meta` (EditLink/LastUpdated container) has `margin-top: 3rem`
+- `.sl-container > * + *` adds `margin-top: 1.5rem` between children
+- `.content-panel` has `padding: 1.5rem var(--sl-content-pad-x)`
+
+To reduce gaps when hiding EditLink, override in `custom.css`:
+```css
+footer.sl-flex .meta {
+  margin-top: 0;
+}
+footer.sl-flex .meta:empty {
+  display: none;
+}
+```

--- a/astro.config.ts
+++ b/astro.config.ts
@@ -46,9 +46,9 @@ export default defineConfig({
           href: 'https://github.com/superfly/sprites-docs',
         },
       ],
-      editLink: {
-        baseUrl: 'https://github.com/superfly/sprites-docs/edit/main/',
-      },
+      // editLink: {
+      //   baseUrl: 'https://github.com/superfly/sprites-docs/edit/main/',
+      // },
       sidebar: withBadges(sidebarConfig),
       head: [
         // Upgrade HTTP requests to HTTPS (workaround for Astro prefetch bug #13570)

--- a/src/components/react/PageFeedback.tsx
+++ b/src/components/react/PageFeedback.tsx
@@ -1,0 +1,123 @@
+import { motion } from 'motion/react';
+import { useState } from 'react';
+import { Button } from '@/components/ui/button';
+
+declare global {
+  interface Window {
+    plausible?: (
+      event: string,
+      options?: { props?: Record<string, string | number> },
+    ) => void;
+  }
+}
+
+const ThumbsUp = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M7 10v12" />
+    <path d="M15 5.88 14 10h5.83a2 2 0 0 1 1.92 2.56l-2.33 8A2 2 0 0 1 17.5 22H4a2 2 0 0 1-2-2v-8a2 2 0 0 1 2-2h2.76a2 2 0 0 0 1.79-1.11L12 2a3.13 3.13 0 0 1 3 3.88Z" />
+  </svg>
+);
+
+const ThumbsDown = ({ className }: { className?: string }) => (
+  <svg
+    className={className}
+    viewBox="0 0 24 24"
+    fill="none"
+    stroke="currentColor"
+    strokeWidth={2}
+    strokeLinecap="round"
+    strokeLinejoin="round"
+    aria-hidden="true"
+  >
+    <path d="M17 14V2" />
+    <path d="M9 18.12 10 14H4.17a2 2 0 0 1-1.92-2.56l2.33-8A2 2 0 0 1 6.5 2H20a2 2 0 0 1 2 2v8a2 2 0 0 1-2 2h-2.76a2 2 0 0 0-1.79 1.11L12 22a3.13 3.13 0 0 1-3-3.88Z" />
+  </svg>
+);
+
+export function PageFeedback() {
+  const [submitted, setSubmitted] = useState<'yes' | 'no' | null>(null);
+
+  const handleFeedback = (helpful: boolean) => {
+    const path = window.location.pathname;
+    window.plausible?.('Feedback', {
+      props: { helpful: helpful ? 'yes' : 'no', path },
+    });
+    setSubmitted(helpful ? 'yes' : 'no');
+  };
+
+  if (submitted) {
+    return (
+      <div
+        className="flex items-center justify-center gap-2 py-4 text-sm text-muted-foreground"
+        style={{ marginBottom: '2.5rem' }}
+      >
+        <motion.svg
+          className="size-5 text-green-500"
+          viewBox="0 0 24 24"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2.5}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+          initial={{ scale: 0, opacity: 0 }}
+          animate={{ scale: 1, opacity: 1 }}
+          transition={{ type: 'spring', stiffness: 300, damping: 20 }}
+        >
+          <motion.path
+            d="M5 12l5 5L20 7"
+            initial={{ pathLength: 0 }}
+            animate={{ pathLength: 1 }}
+            transition={{ duration: 0.3, delay: 0.1 }}
+          />
+        </motion.svg>
+        <motion.span
+          initial={{ opacity: 0, x: -10 }}
+          animate={{ opacity: 1, x: 0 }}
+          transition={{ delay: 0.2 }}
+        >
+          Thanks for your feedback!
+        </motion.span>
+      </div>
+    );
+  }
+
+  return (
+    <div
+      className="flex items-center justify-center gap-4 py-4"
+      style={{ marginBottom: '2.5rem' }}
+    >
+      <span className="text-sm text-muted-foreground">
+        Was this page helpful?
+      </span>
+      <div className="flex gap-2">
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => handleFeedback(true)}
+          className="gap-1.5"
+        >
+          <ThumbsUp className="size-4" />
+          Yes
+        </Button>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => handleFeedback(false)}
+          className="gap-1.5"
+        >
+          <ThumbsDown className="size-4" />
+          No
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/src/components/react/Pagination.tsx
+++ b/src/components/react/Pagination.tsx
@@ -1,4 +1,5 @@
 import { Button } from '@/components/ui/button';
+import { PageFeedback } from './PageFeedback';
 
 interface PaginationLink {
   href: string;
@@ -30,26 +31,26 @@ const PixelArrow = ({
 
 export function Pagination({ prev, next, dir = 'ltr' }: PaginationProps) {
   return (
-    <div
-      className="flex justify-between items-center gap-4 mt-8 print:hidden"
-      dir={dir}
-    >
-      {prev && (
-        <Button variant="outline" size="sm" asChild className="group mr-auto">
-          <a href={prev.href} rel="prev">
-            <PixelArrow direction="left" />
-            <span className="leading-none">{prev.label}</span>
-          </a>
-        </Button>
-      )}
-      {next && (
-        <Button variant="outline" size="sm" asChild className="group ml-auto">
-          <a href={next.href} rel="next">
-            <span className="leading-none">{next.label}</span>
-            <PixelArrow direction="right" />
-          </a>
-        </Button>
-      )}
+    <div className="print:hidden" dir={dir}>
+      <PageFeedback />
+      <div className="flex justify-between items-center gap-4">
+        {prev && (
+          <Button variant="outline" size="sm" asChild className="group mr-auto">
+            <a href={prev.href} rel="prev">
+              <PixelArrow direction="left" />
+              <span className="leading-none">{prev.label}</span>
+            </a>
+          </Button>
+        )}
+        {next && (
+          <Button variant="outline" size="sm" asChild className="group ml-auto">
+            <a href={next.href} rel="next">
+              <span className="leading-none">{next.label}</span>
+              <PixelArrow direction="right" />
+            </a>
+          </Button>
+        )}
+      </div>
     </div>
   );
 }

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -995,3 +995,12 @@ body.search-dialog-open .page {
   color: oklch(0.45 0 0);
   border: 1px solid oklch(0.5 0 0 / 20%);
 }
+
+/* Reduce gap before pagination when EditLink/LastUpdated are hidden */
+footer.sl-flex .meta {
+  margin-top: 0;
+}
+
+footer.sl-flex .meta:empty {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Adds "Was this page helpful?" feedback widget at the bottom of doc pages
- Tracks `Feedback` events to Plausible with `helpful` (yes/no) and `path` properties
- Shows animated green checkmark confirmation after submitting
- Hides EditLink from footer, fixes spacing when meta section is empty
- Documents Starlight CSS specificity findings in CLAUDE.md

## Test plan
- [x] Click Yes/No on feedback widget - verify animated confirmation appears
- [x] Check Plausible dashboard for `Feedback` events with correct props
- [x] Verify spacing between content and feedback/pagination looks correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)