### PR TITLE
Add responsive YouTube video embed to homepage

### DIFF
--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -8,6 +8,18 @@ import { LinkCard, CardGrid } from '@/components/react';
 
 **Sprites are persistent, hardware-isolated Linux environments for running arbitrary code.** It's like having a small, stateful computer you can spin up on demand. Unlike serverless functions, Sprites keep their filesystem and memory between runs. They're useful for things like AI agents, persistent development environments, or user-submitted code.
 
+<div style="position: relative; padding-bottom: 56.25%; height: 0; overflow: hidden; max-width: 100%;">
+  <iframe
+    style="position: absolute; top: 0; left: 0; width: 100%; height: 100%;"
+    src="https://www.youtube-nocookie.com/embed/7BfTLlwO4hw?si=GQunJ-L-RZvTYau5"
+    title="YouTube video player"
+    frameborder="0"
+    allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share"
+    referrerpolicy="strict-origin-when-cross-origin"
+    allowfullscreen
+  ></iframe>
+</div>
+
 ## What makes Sprites different?
 
 | Feature | Traditional Serverless | Sprites |


### PR DESCRIPTION
## Summary
- Embeds the Sprites introduction video on the overview page
- Uses responsive wrapper with 16:9 aspect ratio (padding-bottom technique)
- Video scales properly on mobile devices

## Test plan
- [x] View homepage on desktop and verify video displays correctly
- [x] Test on mobile viewport to confirm responsive scaling
- [x] Verify video plays when clicked

🤖 Generated with [Claude Code](https://claude.ai/code)