### PR TITLE
Add basic auth to nginx

### DIFF
--- a/.htpasswd
+++ b/.htpasswd
@@ -1,0 +1,1 @@
+sprites:$apr1$DhpIgP1k$ZYo9mH0DVr.CLZCGJ0AqZ/

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,6 +25,7 @@ RUN pnpm run build
 FROM nginx:alpine
 
 COPY nginx.conf /etc/nginx/conf.d/default.conf
+COPY .htpasswd /etc/nginx/.htpasswd
 COPY --from=build /app/dist /usr/share/nginx/html
 
 EXPOSE 80

--- a/nginx.conf
+++ b/nginx.conf
@@ -3,6 +3,9 @@ server {
     root /usr/share/nginx/html;
     error_page 404 /404.html;
 
+    auth_basic "Restricted";
+    auth_basic_user_file /etc/nginx/.htpasswd;
+
     location / {
         try_files $uri $uri/ $uri.html =404;
     }


### PR DESCRIPTION
## Summary
- Adds HTTP basic authentication to protect the docs site
- Configures nginx with `auth_basic` directives
- Includes `.htpasswd` file with credentials

## Test plan
- [ ] Deploy to staging and verify basic auth prompt appears
- [ ] Confirm correct credentials grant access

🤖 Generated with [Claude Code](https://claude.com/claude-code)