### PR TITLE
Unpublish all pages except Getting Started

### DIFF
--- a/src/content/docs/api/rest.mdx
+++ b/src/content/docs/api/rest.mdx
@@ -1,6 +1,7 @@
 ---
 title: REST API Reference
 description: HTTP API for managing Sprites programmatically
+draft: true
 ---
 
 import APIEndpoint from '@/components/APIEndpoint.astro';

--- a/src/content/docs/cli/authentication.mdx
+++ b/src/content/docs/cli/authentication.mdx
@@ -1,6 +1,7 @@
 ---
 title: CLI Authentication
 description: Authenticate the Sprites CLI with your Fly.io account
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/cli/commands.mdx
+++ b/src/content/docs/cli/commands.mdx
@@ -1,6 +1,7 @@
 ---
 title: CLI Commands Reference
 description: Complete reference for all Sprites CLI commands
+draft: true
 ---
 
 import { Callout, LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/cli/installation.mdx
+++ b/src/content/docs/cli/installation.mdx
@@ -1,6 +1,7 @@
 ---
 title: CLI Installation
 description: Install the Sprites CLI on macOS, Linux, or Windows
+draft: true
 ---
 
 import { Callout, LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/concepts/checkpoints.mdx
+++ b/src/content/docs/concepts/checkpoints.mdx
@@ -1,6 +1,7 @@
 ---
 title: Checkpoints
 description: Save and restore Sprite state with checkpoints
+draft: true
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/content/docs/concepts/lifecycle.mdx
+++ b/src/content/docs/concepts/lifecycle.mdx
@@ -1,6 +1,7 @@
 ---
 title: Lifecycle and Persistence
 description: Understanding Sprite hibernation, persistence, and state management
+draft: true
 ---
 
 import LifecycleDiagram from '@/components/LifecycleDiagram.astro';

--- a/src/content/docs/concepts/networking.mdx
+++ b/src/content/docs/concepts/networking.mdx
@@ -1,6 +1,7 @@
 ---
 title: Networking
 description: HTTP access, URLs, port forwarding, and network configuration
+draft: true
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/content/docs/concepts/services.mdx
+++ b/src/content/docs/concepts/services.mdx
@@ -1,6 +1,7 @@
 ---
 title: Services
 description: Long-running processes that persist across Sprite reboots
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/reference/base-images.mdx
+++ b/src/content/docs/reference/base-images.mdx
@@ -1,6 +1,7 @@
 ---
 title: Base Images
 description: Pre-configured development environments for Sprites
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/reference/billing.mdx
+++ b/src/content/docs/reference/billing.mdx
@@ -1,6 +1,7 @@
 ---
 title: Billing
 description: Sprites pricing and billing details
+draft: true
 ---
 
 import BillingCalculator from '@/components/BillingCalculator.astro';

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -1,6 +1,7 @@
 ---
 title: Configuration Reference
 description: All configuration options for Sprites
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/sdks/elixir.mdx
+++ b/src/content/docs/sdks/elixir.mdx
@@ -1,6 +1,7 @@
 ---
 title: Elixir SDK
 description: Use Sprites programmatically with the Elixir SDK
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/sdks/go.mdx
+++ b/src/content/docs/sdks/go.mdx
@@ -1,6 +1,7 @@
 ---
 title: Go SDK
 description: Use Sprites programmatically with the Go SDK
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/sdks/javascript.mdx
+++ b/src/content/docs/sdks/javascript.mdx
@@ -1,6 +1,7 @@
 ---
 title: JavaScript SDK
 description: Use Sprites programmatically with the JavaScript/TypeScript SDK
+draft: true
 ---
 
 import { LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/sprites.mdx
+++ b/src/content/docs/sprites.mdx
@@ -1,6 +1,7 @@
 ---
 title: Sprites
 description: Create and manage persistent execution environments programmatically
+draft: true
 ---
 
 import { Tabs, TabItem } from '@astrojs/starlight/components';

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -108,41 +108,4 @@ export const sidebarConfig: SidebarGroup[] = [
       { label: 'Working with Sprites', slug: 'working-with-sprites' },
     ],
   },
-  {
-    label: 'Concepts',
-    items: [
-      { label: 'Lifecycle', slug: 'concepts/lifecycle' },
-      { label: 'Services', slug: 'concepts/services' },
-      { label: 'Networking', slug: 'concepts/networking' },
-      { label: 'Checkpoints', slug: 'concepts/checkpoints' },
-    ],
-  },
-  {
-    label: 'CLI',
-    items: [
-      { label: 'Installation', slug: 'cli/installation' },
-      { label: 'Authentication', slug: 'cli/authentication' },
-      { label: 'Commands', slug: 'cli/commands' },
-    ],
-  },
-  {
-    label: 'SDKs',
-    items: [
-      { label: 'JavaScript', slug: 'sdks/javascript' },
-      { label: 'Go', slug: 'sdks/go' },
-      { label: 'Elixir', slug: 'sdks/elixir' },
-    ],
-  },
-  {
-    label: 'API',
-    items: [{ label: 'Sprites API v1', link: 'https://sprites.dev/api' }],
-  },
-  {
-    label: 'Reference',
-    items: [
-      { label: 'Base Images', slug: 'reference/base-images' },
-      { label: 'Configuration', slug: 'reference/configuration' },
-      { label: 'Billing', slug: 'reference/billing' },
-    ],
-  },
 ];


### PR DESCRIPTION
## Summary
- Marks 15 documentation pages as drafts by adding `draft: true` to frontmatter
- Updates sidebar configuration to only show Getting Started section
- Keeps Overview, Quickstart, and Working with Sprites pages published

## Test plan
- [x] Verify the site builds successfully
- [x] Confirm only Getting Started pages appear in the sidebar
- [x] Check that draft pages return 404 or are not accessible

🤖 Generated with [Claude Code](https://claude.com/claude-code)