### PR TITLE
minor fix to sprite sessions command format

### DIFF
--- a/src/content/docs/working-with-sprites.mdx
+++ b/src/content/docs/working-with-sprites.mdx
@@ -49,7 +49,8 @@ All TTY sessions are automatically detachable. Start a command, disconnect with 
 sprite exec -tty "npm run dev"   # start a TTY session
 # Press Ctrl+\ to detach
 
-sprite sessions                  # list running sessions
+sprite sessions list             # list running sessions
+sprite s ls                      # short form list sessions
 sprite sessions attach <id>      # reattach to session
 sprite sessions kill <id>        # kill session
 ```


### PR DESCRIPTION
- fixed `sprite sessions`  command, requires a subcommand `sprite sessions list`
- added short form `sprite s ls`