### PR TITLE
Fix instructions for mounting Sprite over SSHFS

### DIFF
--- a/src/content/docs/working-with-sprites.mdx
+++ b/src/content/docs/working-with-sprites.mdx
@@ -232,6 +232,10 @@ These features are useful once you're comfortable.
 
 Use SSHFS to mount your Sprite and edit files with your local tools.
 
+Sprites don't expose SSH directly—you'll need to install an SSH server on your 
+Sprite and tunnel the connection through `sprite proxy`. This keeps your Sprite 
+secure while still allowing local filesystem access.
+
 **Prepare an SSH server on your Sprite:**
 
 ```bash
@@ -259,33 +263,38 @@ sudo dnf install fuse-sshfs
 
 ```bash
 sprite exec mkdir -p .ssh
-cat ~/.ssh/id_*.pub | sprite exec tee -a .ssh/authorized_keys
+sprite exec bash -c "echo '$(cat ~/.ssh/id_*.pub)' >> .ssh/authorized_keys"
 ```
 
 **Add this helper to your shell config:**
 
 ```bash
 # Add to ~/.zshrc or ~/.bashrc
-sc() {
+spritemount() {
   local sprite_name="$1"
-  local mount_point="/tmp/sprite-${sprite_name}"
-  test -n "$(sprite url -s "${sprite_name}")"
+  local mount_point="/tmp/sprite-mount"
   mkdir -p "$mount_point"
-  sprite proxy -s "${sprite_name}" 2000:22 &
+  if pid=$(lsof -t -i :2000); then
+    read -rp "A Sprite is already mounted, unmount it? (y/n) " yn
+    [ "$yn" == "y" ] || return 1
+    kill $pid && umount "$mount_point"
+  fi
+  sprite proxy -s "$sprite_name" 2000:22 &
+  sleep 1  # wait for the proxy to start
   sshfs -o reconnect,ServerAliveInterval=15,ServerAliveCountMax=3 \
     "sprite@localhost:" -p 2000 "$mount_point"
-  cd "$mount_point"
+  cd "$mount_point" || return 1
 }
 
-# Mount the sprite with "sc my-sprite"
+# Mount the sprite with "spritemount my-sprite"
 ```
 
 **Unmount when done:**
 
 ```bash
-umount /tmp/sprite-my-sprite
-# macOS may need: diskutil umount /tmp/sprite-my-sprite
-kill "$(lsof -t -i:2000)"
+umount /tmp/sprite-mount
+# macOS may need: diskutil umount /tmp/sprite-mount
+kill $(lsof -t -i:2000)
 ```
 
 ### Common Error Scenarios


### PR DESCRIPTION
Note that the `sprite exec tee` command doesn't currently work (it will produce an invalid file and then hang). This is a bug with how sprite exec handles stdin for non-interactive commands. This should be fixed shortly.