### PR TITLE
quickstart: Fix `sprite destroy <name>` to `sprite destroy -s <name>`

### DIFF
--- a/src/content/docs/quickstart.mdx
+++ b/src/content/docs/quickstart.mdx
@@ -58,7 +58,7 @@ Set it as your active Sprite to avoid adding `-s my-first-sprite` to every comma
 sprite use my-first-sprite
 ```
 
-Use `sprite list` to see all your Sprites, or `sprite destroy my-first-sprite` when you're done with one. You can have multiple Sprites running simultaneously—each with its own isolated environment.
+Use `sprite list` to see all your Sprites, or `sprite destroy -s my-first-sprite` when you're done with one. You can have multiple Sprites running simultaneously—each with its own isolated environment.
 
 ## Run Commands
 


### PR DESCRIPTION
Quickstart currently says `sprite destroy <name>` but running that will give you:

```console
$ sprite destroy linux-am64-box
Error: destroy takes no arguments

Destroy the current sprite

Usage:
  sprite destroy [options]

Examples:
  sprite destroy
  sprite destroy -o myorg -s mysprite
  sprite destroy --force
```

`sprite destroy -s <name>` seems to do the invocation correctly.

(But note that the invocation fails for me:

```console
$ sprite destroy -s linux-am64-box
malthe-jorgensen: About to destroy sprite linux-am64-box

Error: Failed to destroy sprite: failed to delete sprite
```
)