### PR TITLE
Fix sprite destroy syntax to require -s flag

### DIFF
--- a/scripts/generate-cli-docs/cli-runner.ts
+++ b/scripts/generate-cli-docs/cli-runner.ts
@@ -119,7 +119,7 @@ export async function createTestSprite(): Promise<string> {
   const useResult = await runCommand(['sprite', 'use', spriteName]);
   if (!useResult.success) {
     // Try to cleanup
-    await runCommand(['sprite', 'destroy', spriteName]);
+    await runCommand(['sprite', 'destroy', '-s', spriteName]);
     throw new Error(`Failed to set test sprite: ${useResult.stderr}`);
   }
 

--- a/src/content/docs/quickstart.mdx
+++ b/src/content/docs/quickstart.mdx
@@ -58,7 +58,7 @@ Set it as your active Sprite to avoid adding `-s my-first-sprite` to every comma
 sprite use my-first-sprite
 ```
 
-Use `sprite list` to see all your Sprites, or `sprite destroy my-first-sprite` when you're done with one. You can have multiple Sprites running simultaneously—each with its own isolated environment.
+Use `sprite list` to see all your Sprites, or `sprite destroy -s my-first-sprite` when you're done with one. You can have multiple Sprites running simultaneously—each with its own isolated environment.
 
 ## Run Commands
 

--- a/src/content/docs/sprites.mdx
+++ b/src/content/docs/sprites.mdx
@@ -31,7 +31,7 @@ sprite exec python -c "print('hello')"
 sprite exec "for i in {1..10}; do date +%T; sleep 0.5; done"
 
 # Destroy when done
-sprite destroy my-sprite
+sprite destroy -s my-sprite
 ```
 </TabItem>
 
@@ -783,7 +783,7 @@ Always clean up Sprites when you're done:
 <Tabs>
 <TabItem label="CLI">
 ```bash
-sprite destroy my-sprite
+sprite destroy -s my-sprite
 ```
 </TabItem>
 

--- a/src/content/docs/working-with-sprites.mdx
+++ b/src/content/docs/working-with-sprites.mdx
@@ -188,7 +188,7 @@ sprite list --prefix "dev-"
 ### Destroy
 
 ```bash
-sprite destroy my-sprite
+sprite destroy -s my-sprite
 ```
 
 <Callout type="warning">


### PR DESCRIPTION
## Summary
- Fixed documentation inconsistency where `sprite destroy my-sprite` was used instead of the correct `sprite destroy -s my-sprite` syntax
- Updated `quickstart.mdx`, `sprites.mdx`, `working-with-sprites.mdx`, and `cli-runner.ts` script
- The CLI reference documents `sprite destroy [options]` without a positional argument, so the `-s` flag is required

## Test plan
- [ ] Verify the updated examples match the CLI reference documentation
- [x] Test that `sprite destroy -s sprite-name` works correctly with the CLI

🤖 Generated with [Claude Code](https://claude.com/claude-code)