### PR TITLE
Remove SDK cards from API reference overview page

### DIFF
--- a/scripts/generate-api-docs.ts
+++ b/scripts/generate-api-docs.ts
@@ -1066,41 +1066,6 @@ ${categories
   .join('\n')}
 </CardGrid>
 
-## SDK Libraries
-
-For a better developer experience, use our official SDKs:
-
-<CardGrid client:load>
-  <LinkCard
-    href="/sdks/javascript"
-    title="JavaScript SDK"
-    description="TypeScript/JavaScript client"
-    icon="code"
-    client:load
-  />
-  <LinkCard
-    href="/sdks/go"
-    title="Go SDK"
-    description="Native Go client"
-    icon="code"
-    client:load
-  />
-  <LinkCard
-    href="/sdks/python"
-    title="Python SDK"
-    description="Python client library"
-    icon="code"
-    client:load
-  />
-  <LinkCard
-    href="/sdks/elixir"
-    title="Elixir SDK"
-    description="Elixir client library"
-    icon="code"
-    client:load
-  />
-</CardGrid>
-
 ## Version
 
 API Version: \`${schema.version}\`


### PR DESCRIPTION
## Summary
- Removes the SDK Libraries section from the generated API reference index page
- SDK pages don't all exist yet, so removing the links until they're ready

## Test plan
- [x] Build passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)