### PR TITLE
Rename "cold storage" to "storage" in docs

### DIFF
--- a/src/components/react/PricingRates.tsx
+++ b/src/components/react/PricingRates.tsx
@@ -5,7 +5,7 @@ export const HOURLY_RATES = {
   cpu: 0.07,
   ram: 0.04375,
   storageHot: 0.5,
-  storageCold: 0.02,
+  storage: 0.02,
 };
 
 export function PricingRates() {
@@ -60,8 +60,8 @@ export function PricingRates() {
           description="Local NVMe cache for active working data, sampled every few seconds."
         />
         <RateCard
-          title="Cold Storage"
-          rate={`$${HOURLY_RATES.storageCold.toFixed(2)}`}
+          title="Storage"
+          rate={`$${HOURLY_RATES.storage.toFixed(2)}`}
           unit="/GB-month"
           description="Object storage for persistent data, measured hourly."
         />
@@ -69,7 +69,7 @@ export function PricingRates() {
 
       <p className="text-xs text-[var(--sl-color-gray-2)] pt-2 border-t border-[var(--sl-color-hairline)]">
         All compute resources are billed per second. Hot storage is sampled
-        every few seconds while active; cold storage is measured hourly.
+        every few seconds while active; storage is measured hourly.
       </p>
     </div>
   );

--- a/src/content/docs/reference/billing.mdx
+++ b/src/content/docs/reference/billing.mdx
@@ -56,7 +56,7 @@ Compute is billed **per-second** with no minimum. If you run a command for 30 se
 
 ## Storage Billing
 
-Sprites use a two-tier storage system: **hot storage** for active working data and **cold storage** for persistent object storage.
+Sprites use a two-tier storage system: **hot storage** for active working data and **storage** for persistent object storage.
 
 ### Hot Storage
 
@@ -68,12 +68,12 @@ Hot storage is the local NVMe cache used by the filesystem (JuiceFS) for active 
 
 Hot storage represents the working set of data actively being used during your session.
 
-### Cold Storage
+### Storage
 
-Cold storage is the object storage bucket where all your Sprite's persistent data lives.
+Storage is the object storage bucket where all your Sprite's persistent data lives.
 
 - **Measured hourly** by summing the actual size of all objects in your bucket
-- **Always charged**: Cold storage accrues 24/7, even when hibernated
+- **Always charged**: Storage accrues 24/7, even when hibernated
 - **TRIM-friendly**: You only pay for data actually written
 - **Deleted files reduce cost**: Deleting files reduces your storage bill
 
@@ -83,7 +83,7 @@ Every Sprite includes 100 GB of storage capacity. Storage does not autoscale yet
 
 ### Typical Usage
 
-| Environment | Hot Storage (active) | Cold Storage | Within Plan? |
+| Environment | Hot Storage (active) | Storage | Within Plan? |
 |------------|---------------------|--------------|--------------|
 | Minimal (OS + tools) | ~1 GB | ~2 GB | Yes |
 | Dev environment | ~2 GB | ~5 GB | Yes |
@@ -149,10 +149,10 @@ Usage and billing information is available through your Fly.io dashboard and org
 > Compute billing starts when you execute a command and stops when the command completes or the Sprite hibernates.
 
 **Do I pay while hibernated?**
-> No compute or hot storage charges while hibernated. You only pay for cold storage (object storage), which accrues 24/7.
+> No compute or hot storage charges while hibernated. You only pay for storage (object storage), which accrues 24/7.
 
 **How is storage measured?**
-> Hot storage (NVMe cache) is sampled every few seconds while your Sprite is active. Cold storage (object storage) is measured hourly based on actual data stored, not allocated capacity.
+> Hot storage (NVMe cache) is sampled every few seconds while your Sprite is active. Storage (object storage) is measured hourly based on actual data stored, not allocated capacity.
 
 **Are checkpoints billed?**
 > Yes, checkpoints count toward your storage usage.


### PR DESCRIPTION
## Summary
- Renames "cold storage" to just "storage" throughout the documentation
- "Hot storage" remains unchanged
- Updates PricingRates component and billing reference docs

## Test plan
- [ ] Verify PricingRates component shows "Storage" instead of "Cold Storage"
- [ ] Verify billing.mdx content reflects the new terminology
- [ ] Confirm "Hot storage" references are unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)