### PR TITLE
Add styling to distinguish table headers

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -586,8 +586,9 @@ nav.sidebar {
   padding: 0.5rem 1rem;
   text-align: left;
   vertical-align: middle;
-  font-weight: 500;
+  font-weight: 700;
   color: var(--foreground);
+  background-color: var(--muted);
 }
 
 .sl-markdown-content [data-slot="table-cell"] {


### PR DESCRIPTION
## Summary
- Adds subtle background color (`var(--muted)`) to table header cells
- Increases font weight from 500 to 700 for better visual hierarchy