### PR TITLE
Hide API Reference from sidebar

### DIFF
--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -118,10 +118,10 @@ export const sidebarConfig: SidebarGroup[] = [
       { label: 'Commands', slug: 'cli/commands' },
     ],
   },
-  {
-    label: 'API Reference',
-    // Items are auto-generated from API schema by scripts/generate-api-docs.ts
-    // Links are dynamically rewritten by Sidebar.astro based on current URL version
-    items: apiSidebarConfig,
-  },
+  // {
+  //   label: 'API Reference',
+  //   // Items are auto-generated from API schema by scripts/generate-api-docs.ts
+  //   // Links are dynamically rewritten by Sidebar.astro based on current URL version
+  //   items: apiSidebarConfig,
+  // },
 ];


### PR DESCRIPTION
## Summary
- Removes the API Reference section from the sidebar navigation
- API docs pages remain accessible via direct URL, just hidden from the sidebar

## Test plan
- [ ] Verify the sidebar no longer shows the "API Reference" section
- [ ] Verify API doc pages are still accessible via direct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)