### PR TITLE
Fix instructions for checking OS version

### DIFF
--- a/src/content/docs/sprite-maintenance.mdx
+++ b/src/content/docs/sprite-maintenance.mdx
@@ -17,7 +17,7 @@ New Sprites run on a fresh install of Ubuntu 25.10. Older Sprites created with U
 If you don't know what version of Ubuntu your Sprite currently runs, check with:
 
 ```bash
-lsb_release -d
+cat /etc/*release
 ```
 </Callout>
 


### PR DESCRIPTION
Sprites don't have `lsb_release` installed by default. It's ugly, but
`cat` always works.