### PR TITLE
Fix broken manual installation instructions

### DIFF
--- a/src/components/CliDownloads.astro
+++ b/src/components/CliDownloads.astro
@@ -16,12 +16,11 @@ const instructions = [
     steps: [
       {
         label: 'Download the binary',
-        code: `curl -LO ${darwinArm64.url}`,
+        code: `curl -LO \\\n  ${darwinArm64.url}`,
       },
       {
         label: 'Verify checksum (recommended)',
-        code: `curl -LO ${darwinArm64.checksumUrl}
-shasum -a 256 -c ${darwinArm64.filename}.sha256`,
+        code: `curl -sL ${darwinArm64.checksumUrl} \\\n  | awk '{print $1 "  ${darwinArm64.filename}"}' | shasum -a 256 -c`,
       },
       {
         label: 'Extract and install',
@@ -36,12 +35,11 @@ sudo mv sprite /usr/local/bin/`,
     steps: [
       {
         label: 'Download the binary',
-        code: `curl -LO ${linuxAmd64.url}`,
+        code: `curl -LO \\\n  ${linuxAmd64.url}`,
       },
       {
         label: 'Verify checksum (recommended)',
-        code: `curl -LO ${linuxAmd64.checksumUrl}
-sha256sum -c ${linuxAmd64.filename}.sha256`,
+        code: `curl -sL ${linuxAmd64.checksumUrl} \\\n  | awk '{print $1 "  ${linuxAmd64.filename}"}' | sha256sum -c`,
       },
       {
         label: 'Extract and install',
@@ -56,7 +54,7 @@ sudo mv sprite /usr/local/bin/`,
     steps: [
       {
         label: 'Download the binary',
-        code: `Invoke-WebRequest -Uri "${windowsAmd64.url}" -OutFile "${windowsAmd64.filename}"`,
+        code: `Invoke-WebRequest \`\n  -Uri "${windowsAmd64.url}" \`\n  -OutFile "${windowsAmd64.filename}"`,
       },
       {
         label: 'Extract to your bin directory',

--- a/src/lib/cli-releases.ts
+++ b/src/lib/cli-releases.ts
@@ -25,7 +25,9 @@ const PLATFORMS = [
 async function fetchLatestVersion(): Promise<string> {
   const response = await fetch(`${BINARIES_BASE_URL}/client/rc.txt`);
   if (!response.ok) {
-    throw new Error(`Failed to fetch latest RC version: ${response.statusText}`);
+    throw new Error(
+      `Failed to fetch latest RC version: ${response.statusText}`,
+    );
   }
   const version = (await response.text()).trim();
   if (!version) {

--- a/src/lib/cli-releases.ts
+++ b/src/lib/cli-releases.ts
@@ -22,6 +22,18 @@ const PLATFORMS = [
   { platform: 'Windows', arch: 'ARM64', key: 'windows-arm64' },
 ] as const;
 
+async function fetchLatestVersion(): Promise<string> {
+  const response = await fetch(`${BINARIES_BASE_URL}/client/rc.txt`);
+  if (!response.ok) {
+    throw new Error(`Failed to fetch latest RC version: ${response.statusText}`);
+  }
+  const version = (await response.text()).trim();
+  if (!version) {
+    throw new Error('Empty version string from rc.txt');
+  }
+  return version;
+}
+
 function buildBinaries(version: string): CliBinary[] {
   return PLATFORMS.map(({ platform, arch, key }) => {
     const ext = key.startsWith('windows') ? 'zip' : 'tar.gz';
@@ -38,8 +50,7 @@ function buildBinaries(version: string): CliBinary[] {
 }
 
 export async function getLatestRcRelease(): Promise<CliRelease> {
-  const response = await fetch(`${BINARIES_BASE_URL}/client/rc.txt`);
-  const version = await response.text();
+  const version = await fetchLatestVersion();
 
   return {
     version,


### PR DESCRIPTION
## Summary

- Fix checksum verification failing because `.sha256` file references a subfolder path (`sprite-darwin-arm64/sprite-darwin-arm64.tar.gz`) while the user downloads the file to the current directory
- Add line continuations (`\`) to long `curl` commands to prevent copy-paste issues from visual line wrapping
- Add error handling to the CLI version fetch (check response status, trim whitespace, validate non-empty)

Closes #162

## Testing

Verify on the preview deployment that `/cli/installation/` renders code blocks without unintended wrapping and that the commands copy cleanly. The checksum verification command can be validated by running it against a real download.

Testing done.