### PR TITLE
Add remote MCP server docs

### DIFF
--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -1,0 +1,126 @@
+---
+title: Remote MCP Server
+description: Connect MCP clients to Sprites with the hosted remote MCP server
+---
+
+import { Callout } from '@/components/react';
+
+Sprites provides a hosted remote MCP server. Once connected, an MCP client can create and manage Sprites, run commands inside them, inspect checkpoints and services, and adjust network policy through standard MCP tools.
+
+Use it when you want an MCP client to work in isolated, persistent Linux environments without copying API tokens into prompts or running a local MCP bridge.
+
+## MCP server URL
+
+Use this URL when adding the connector:
+
+```text
+https://sprites.dev/mcp
+```
+
+The connector uses OAuth. During setup, you sign in with your Fly.io account, choose the organization the client should use, and approve the level of Sprites access for that connector.
+
+## Add the connector
+
+1. Open your MCP client's connector settings.
+2. Add a custom or remote MCP connector.
+3. Enter `https://sprites.dev/mcp`.
+4. Follow the browser authentication flow.
+5. Choose the Sprites organization the connector should use.
+6. Review the token restrictions on the consent screen and approve the connection.
+
+<Callout type="info">
+If your client asks for a connector name, use `Sprites`.
+</Callout>
+
+## Permissions
+
+By default, the OAuth consent flow creates a restricted Sprites token for the MCP connector. The default restriction allows the connector to create Sprites with the `mcp-` name prefix and limits the number of Sprites it can create.
+
+During consent, you can adjust the name prefix and maximum Sprite count. You can also choose full token access if you want the connector to operate on the organization without those MCP-specific restrictions.
+
+<Callout type="warning">
+Full access lets the connector manage any Sprite the selected organization token can access. Use restricted mode unless your workflow needs broader control.
+</Callout>
+
+## Available tools
+
+MCP clients see Sprites as tools. The hosted server exposes organization-level tools and Sprite-level tools.
+
+### Organization tools
+
+| Tool | Access | What it does |
+|------|--------|--------------|
+| `list_sprites` | Read-only | Lists Sprites visible to the authenticated organization and token policy. |
+| `create_sprite` | Destructive | Creates a Sprite in the selected organization. |
+| `destroy_sprite` | Destructive | Permanently destroys a Sprite. |
+
+### Sprite tools
+
+The Sprite-level tools are generated from the public Sprite environment API. The exact list may change as new Sprite environment versions ship, but commonly includes:
+
+| Category | Examples |
+|----------|----------|
+| Exec | Run a command, list exec sessions, kill a session |
+| Checkpoints | Create, list, inspect, and restore checkpoints |
+| Network policy | Read or update outbound network rules |
+| Services | List, create, start, stop, and inspect background services |
+| Service logs | Read recent service logs |
+
+Tools are annotated as either read-only or destructive. Your MCP client may ask for additional confirmation before using destructive tools, depending on its settings.
+
+## Safety model
+
+Sprites are isolated Linux environments. That isolation is useful for agent work, but MCP tools can still perform real actions in your organization.
+
+- `destroy_sprite` permanently deletes a Sprite and its data.
+- Command execution can modify files, install packages, start services, or use network access allowed by the Sprite policy.
+- Checkpoint restore changes a Sprite back to a previous filesystem state.
+- Network policy updates can allow or block outbound access from a Sprite.
+
+For safer workflows, use a restricted OAuth token, pick a clear name prefix such as `mcp-`, and create a fresh Sprite for experiments.
+
+## Example requests
+
+```text
+Create a Sprite named mcp-demo, run python --version, and tell me what runtime is installed.
+```
+
+```text
+Create a checkpoint on mcp-demo before making changes. Then install ripgrep and verify rg --version.
+```
+
+```text
+List my Sprites with the mcp- prefix and summarize which ones are running.
+```
+
+## Troubleshooting
+
+### The client cannot connect
+
+Check that the connector URL is exactly:
+
+```text
+https://sprites.dev/mcp
+```
+
+The MCP endpoint is not the REST API host. Do not use `https://api.sprites.dev`.
+
+### Authentication loops or fails
+
+Sign out of Fly.io in your browser, sign in again, and retry the connector flow. If you belong to multiple organizations, make sure you select the organization that should own Sprites created through MCP.
+
+### A Sprite is not found
+
+The Sprite may belong to a different organization, may be outside the token's allowed name prefix, or may have been destroyed. Call `list_sprites` and verify the exact Sprite name.
+
+### A parameter is missing
+
+Some tools require an existing Sprite name, service name, checkpoint ID, or exec session ID. List the relevant resource first, then retry the tool call with the exact identifier.
+
+### A Sprite is starting
+
+Cold Sprites can take a moment to wake. If the client receives a retry message, wait a few seconds and run the same tool again.
+
+## REST API reference
+
+The MCP server wraps the same Sprite capabilities documented in the [Sprites API reference](https://sprites.dev/api). Use the API reference when you want endpoint schemas, SDK examples, or direct REST access instead of MCP.

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -5,7 +5,7 @@ description: Connect MCP clients to Sprites with the hosted remote MCP server
 
 import { Callout } from '@/components/react';
 
-Sprites provides a hosted remote MCP server. Once connected, an MCP client can create and manage Sprites, run commands inside them, inspect checkpoints and services, and adjust network policy through standard MCP tools.
+Sprites runs a hosted MCP server. Connect an MCP client to it and the client can control Sprites directly. It can create and manage them, run commands, inspect checkpoints, and change network policy through standard MCP tools.
 
 Use it when you want an MCP client to work in isolated, persistent Linux environments without copying API tokens into prompts or running a local MCP bridge.
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -44,7 +44,7 @@ Full access lets the connector manage any Sprite the selected organization token
 
 ## Available tools
 
-MCP clients see Sprites as tools. The hosted server exposes organization-level tools and Sprite-level tools.
+MCP clients see Sprites as tools. There are two layers: organization-level tools that act across your Sprites, and Sprite-level tools that act inside a specific one.
 
 ### Organization tools
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -22,7 +22,7 @@ The connector uses OAuth. During setup, you sign in with your Fly.io account, ch
 ## Add the connector
 
 1. Open your MCP client's connector settings.
-2. Add a custom or remote MCP connector.
+2. Add a remote (or custom) MCP connector. Different clients label this differently. Look for "Remote MCP server", "Custom connector", or similar.
 3. Enter `https://sprites.dev/mcp`.
 4. Follow the browser authentication flow.
 5. Choose the Sprites organization the connector should use.

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -107,7 +107,7 @@ The MCP endpoint is not the REST API host. Do not use `https://api.sprites.dev`.
 
 ### Authentication loops or fails
 
-Sign out of Fly.io in your browser, sign in again, and retry the connector flow. If you belong to multiple organizations, make sure you select the organization that should own Sprites created through MCP.
+Sign out of Fly.io in your browser, sign in again, and retry the connector flow. If you belong to multiple organizations, make sure you select the one that should own Sprites created through MCP.
 
 ### A Sprite is not found
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -36,7 +36,7 @@ If your client asks for a connector name, use `Sprites`.
 
 The default token is restricted. The connector can only create Sprites whose names start with mcp-, and it can only create a limited number of them.
 
-During consent, you can adjust the name prefix and maximum Sprite count. You can also choose full token access if you want the connector to operate on the organization without those MCP-specific restrictions.
+You can change both on the consent screen: pick a different name prefix, raise or lower the cap, or switch to full access if you want the connector to act on the whole organization without those guardrails.
 
 <Callout type="warning">
 Full access lets the connector manage any Sprite the selected organization token can access. Use restricted mode unless your workflow needs broader control.

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -24,7 +24,7 @@ The connector uses OAuth. During setup, you sign in with your Fly.io account, ch
 1. Open your MCP client's connector settings.
 2. Add a remote (or custom) MCP connector. Different clients label this differently. Look for "Remote MCP server", "Custom connector", or similar.
 3. Enter `https://sprites.dev/mcp`.
-4. Follow the browser authentication flow.
+4. Follow the browser authentication flow for Fly.io
 5. Choose the Sprites organization the connector should use.
 6. Review the token restrictions on the consent screen and approve the connection.
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -7,7 +7,7 @@ import { Callout } from '@/components/react';
 
 Sprites runs a hosted MCP server. Connect an MCP client to it and the client can control Sprites directly. It can create and manage them, run commands, inspect checkpoints, and change network policy through standard MCP tools.
 
-Use it when you want an MCP client to work in isolated, persistent Linux environments without copying API tokens into prompts or running a local MCP bridge.
+Why use it? Your MCP client gets persistent, isolated Linux environments without you pasting API tokens into a prompt or running a local MCP bridge.
 
 ## MCP server URL
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -74,7 +74,7 @@ Sprites are isolated Linux environments. That isolation is useful for agent work
 
 - `destroy_sprite` permanently deletes a Sprite and its data. There is no undo.
 - Command execution can modify files, install packages, start services, or use network access allowed by the Sprite policy.
-- Checkpoint restore changes a Sprite back to a previous filesystem state.
+- Checkpoint restore rewinds a Sprite to a previous filesystem state. Any work done since that checkpoint is gone.
 - Network policy updates can allow or block outbound access from a Sprite.
 
 For safer workflows, use a restricted OAuth token, pick a clear name prefix such as `mcp-`, and create a fresh Sprite for experiments.

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -72,7 +72,7 @@ Tools are annotated as either read-only or destructive. Your MCP client may ask 
 
 Sprites are isolated Linux environments. That isolation is useful for agent work, but MCP tools can still perform real actions in your organization.
 
-- `destroy_sprite` permanently deletes a Sprite and its data.
+- `destroy_sprite` permanently deletes a Sprite and its data. There is no undo.
 - Command execution can modify files, install packages, start services, or use network access allowed by the Sprite policy.
 - Checkpoint restore changes a Sprite back to a previous filesystem state.
 - Network policy updates can allow or block outbound access from a Sprite.

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -34,7 +34,7 @@ If your client asks for a connector name, use `Sprites`.
 
 ## Permissions
 
-By default, the OAuth consent flow creates a restricted Sprites token for the MCP connector. The default restriction allows the connector to create Sprites with the `mcp-` name prefix and limits the number of Sprites it can create.
+The default token is restricted. The connector can only create Sprites whose names start with mcp-, and it can only create a limited number of them.
 
 During consent, you can adjust the name prefix and maximum Sprite count. You can also choose full token access if you want the connector to operate on the organization without those MCP-specific restrictions.
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -24,7 +24,7 @@ The connector uses OAuth. During setup, you sign in with your Fly.io account, ch
 1. Open your MCP client's connector settings.
 2. Add a remote (or custom) MCP connector. Different clients label this differently. Look for "Remote MCP server", "Custom connector", or similar.
 3. Enter `https://sprites.dev/mcp`.
-4. Follow the browser authentication flow for Fly.io
+4. Follow the browser authentication flow for Fly.io.
 5. Choose the Sprites organization the connector should use.
 6. Review the token restrictions on the consent screen and approve the connection.
 

--- a/src/content/docs/integrations/remote-mcp.mdx
+++ b/src/content/docs/integrations/remote-mcp.mdx
@@ -34,7 +34,7 @@ If your client asks for a connector name, use `Sprites`.
 
 ## Permissions
 
-The default token is restricted. The connector can only create Sprites whose names start with mcp-, and it can only create a limited number of them.
+The default token is restricted. The connector can only create Sprites whose names start with `mcp-`, and it can only create a limited number of them.
 
 You can change both on the consent screen: pick a different name prefix, raise or lower the cap, or switch to full access if you want the connector to act on the whole organization without those guardrails.
 

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -1,7 +1,6 @@
 import { execSync } from 'node:child_process';
 import path from 'node:path';
 import type { StarlightUserConfig } from '@astrojs/starlight/types';
-import { apiSidebarConfig } from './api-sidebar';
 
 type SidebarConfig = NonNullable<StarlightUserConfig['sidebar']>;
 type SidebarGroup = Extract<SidebarConfig[number], { items: unknown }>;
@@ -118,6 +117,10 @@ export const sidebarConfig: SidebarGroup[] = [
       { label: 'Authentication', slug: 'cli/authentication' },
       { label: 'Commands', slug: 'cli/commands' },
     ],
+  },
+  {
+    label: 'Integrations',
+    items: [{ label: 'Remote MCP Server', slug: 'integrations/remote-mcp' }],
   },
   // {
   //   label: 'API Reference',


### PR DESCRIPTION
## Summary
- add a vendor-neutral Remote MCP Server guide on the docs site
- document connector URL, OAuth setup, permissions, available tools, safety notes, and troubleshooting
- add the guide to the Integrations sidebar group

## User impact
MCP users get a public, canonical setup guide that is not tied to a single client vendor.

## Validation
- npx --yes pnpm@10.25.0 build
- npx --yes pnpm@10.25.0 lint

## Deployment
Deploy the docs site after merge so https://docs.sprites.dev/integrations/remote-mcp is available before or alongside the API docs cross-link.