### PR TITLE
Publish Connectors concept doc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,7 @@ RUN apt-get update -qq && \
     rm -rf /var/lib/apt/lists/*
 
 # Install dependencies
-COPY package.json pnpm-lock.yaml* ./
+COPY package.json pnpm-lock.yaml* pnpm-workspace.yaml ./
 RUN pnpm install --frozen-lockfile || pnpm install
 
 # Copy and build

--- a/package.json
+++ b/package.json
@@ -56,12 +56,5 @@
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"
-  },
-  "pnpm": {
-    "onlyBuiltDependencies": [
-      "cypress",
-      "esbuild",
-      "sharp"
-    ]
   }
 }

--- a/package.json
+++ b/package.json
@@ -56,5 +56,12 @@
     "tsx": "^4.21.0",
     "tw-animate-css": "^1.4.0",
     "typescript": "^5.9.3"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "cypress",
+      "esbuild",
+      "sharp"
+    ]
   }
 }

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,4 @@
+onlyBuiltDependencies:
+  - cypress
+  - esbuild
+  - sharp

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-onlyBuiltDependencies:
-  - cypress
-  - esbuild
-  - sharp
+allowBuilds:
+  cypress: true
+  esbuild: true
+  sharp: true

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,4 +1,4 @@
-allowBuilds:
-  cypress: true
-  esbuild: true
-  sharp: true
+onlyBuiltDependencies:
+  - cypress
+  - esbuild
+  - sharp

--- a/src/content/docs/concepts/connectors.mdx
+++ b/src/content/docs/concepts/connectors.mdx
@@ -1,7 +1,6 @@
 ---
 title: Connectors
 description: Give Sprites access to external APIs without putting provider credentials inside the Sprite
-draft: true
 ---
 
 import { Callout } from '@/components/react';

--- a/src/content/docs/concepts/connectors.mdx
+++ b/src/content/docs/concepts/connectors.mdx
@@ -92,7 +92,7 @@ The connector detail page shows the exact gateway URL for each connector — you
 The access policy can also restrict which provider paths a Sprite can reach through the connector. This is useful when a connector has more permission than you want any single Sprite to use, for example, a Slack bot that can post messages should probably not be able to call admin endpoints.
 
 <Callout type="info" title="API only for now">
-Endpoint allow- and block-lists aren't yet editable from the dashboard — set them via the [Connectors API](https://sprites.dev/api/connectors).
+Endpoint allow- and block-lists aren't yet editable from the dashboard. Set them via the [Connectors API](https://sprites.dev/api/connectors).
 </Callout>
 
 Patterns are exact paths or trailing-wildcard prefixes:

--- a/src/content/docs/concepts/connectors.mdx
+++ b/src/content/docs/concepts/connectors.mdx
@@ -93,7 +93,11 @@ The connector detail page shows the exact gateway URL for each connector — you
 
 ## Endpoint allow- and block-lists
 
-The Access Configuration card also lets you restrict which provider paths a Sprite can reach through the connector. This is useful when a connector has more permission than you want any single Sprite to use, for example, a Slack bot that can post messages should probably not be able to call admin endpoints.
+The access policy can also restrict which provider paths a Sprite can reach through the connector. This is useful when a connector has more permission than you want any single Sprite to use, for example, a Slack bot that can post messages should probably not be able to call admin endpoints.
+
+<Callout type="info" title="API only for now">
+Endpoint allow- and block-lists aren't yet editable from the dashboard — set them via the [connections API](#automating-with-the-api).
+</Callout>
 
 Patterns are exact paths or trailing-wildcard prefixes:
 

--- a/src/content/docs/concepts/connectors.mdx
+++ b/src/content/docs/concepts/connectors.mdx
@@ -92,7 +92,7 @@ The connector detail page shows the exact gateway URL for each connector — you
 The access policy can also restrict which provider paths a Sprite can reach through the connector. This is useful when a connector has more permission than you want any single Sprite to use, for example, a Slack bot that can post messages should probably not be able to call admin endpoints.
 
 <Callout type="info" title="API only for now">
-Endpoint allow- and block-lists aren't yet editable from the dashboard — set them via the [connections API](#automating-with-the-api).
+Endpoint allow- and block-lists aren't yet editable from the dashboard — set them via the [Connectors API](https://sprites.dev/api/connectors).
 </Callout>
 
 Patterns are exact paths or trailing-wildcard prefixes:

--- a/src/content/docs/concepts/connectors.mdx
+++ b/src/content/docs/concepts/connectors.mdx
@@ -9,10 +9,6 @@ A Sprite that needs to talk to Slack, GitHub, OpenRouter, or another HTTP API ru
 
 Connectors solve this by storing the credential once, in your organization, and routing API calls through the Sprites gateway. Sprites never see the token. You decide which Sprites can use a connector and which provider endpoints they can reach.
 
-<Callout type="info" title="Limited release">
-Connectors are currently behind the `connected_services` feature flag. If you don't see a **Connectors** section in your dashboard, this isn't enabled for your organization yet.
-</Callout>
-
 ## How it works
 
 A connector has three pieces:

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -111,6 +111,10 @@ export const sidebarConfig: SidebarGroup[] = [
     ],
   },
   {
+    label: 'Concepts',
+    items: [{ label: 'Connectors', slug: 'concepts/connectors' }],
+  },
+  {
     label: 'CLI Reference',
     items: [
       { label: 'Installation', slug: 'cli/installation' },


### PR DESCRIPTION
## Summary
- Publish the Connectors concept doc by removing the `draft: true` frontmatter.
- Drop the "Limited release" callout — connectors are no longer behind a feature flag we need to call out.
- Add an "API only for now" note in the **Endpoint allow- and block-lists** section, since the dashboard's Access Configuration card doesn't yet expose `allowed_endpoints` / `blocked_endpoints`. Links readers to the public [Connectors API reference](https://sprites.dev/api/connectors) (added in superfly/sprites-api#579).
- Unblock CI: add `pnpm.onlyBuiltDependencies` for `cypress`, `esbuild`, and `sharp`. pnpm 11 was erroring on every recent CI run (`ERR_PNPM_IGNORED_BUILDS`); this allow-lists the three packages that need to run postinstall scripts.

## Test plan
- [ ] CI build passes (was failing on `pnpm install` for all branches before this fix).
- [ ] `pnpm dev` and visit http://localhost:4321/concepts/connectors/ to confirm the page renders and appears in the sidebar under Concepts.
- [ ] Confirm the "API only for now" callout renders and the link target is correct.