### PR TITLE
Use -- separator in sprite exec examples

### DIFF
--- a/src/content/docs/quickstart.mdx
+++ b/src/content/docs/quickstart.mdx
@@ -68,10 +68,10 @@ Execute commands in your Sprite:
 
 ```bash
 # Run a simple command
-sprite exec echo "Hello, Sprites!"
+sprite exec -- echo "Hello, Sprites!"
 
 # Run multiple commands
-sprite exec bash -c "cd /tmp && ls -la"
+sprite exec -- bash -c "cd /tmp && ls -la"
 
 # Open an interactive shell
 sprite console
@@ -90,7 +90,7 @@ Your Sprite comes pre-configured with common development tools (Node.js, Python,
 See what's already installed and ready to use:
 
 ```bash
-sprite exec bash -c "node --version && python3 --version && go version"
+sprite exec -- bash -c "node --version && python3 --version && go version"
 ```
 
 ### Install a package
@@ -98,7 +98,7 @@ sprite exec bash -c "node --version && python3 --version && go version"
 Install dependencies just like you would locally—they'll stick around:
 
 ```bash
-sprite exec pip install requests
+sprite exec -- pip install requests
 ```
 
 ### Create and read files
@@ -107,12 +107,12 @@ Files you create persist across sessions. Write once, read anytime:
 
 ```bash
 # Create a file
-sprite exec bash -c "echo 'Hello from my persistent Sprite!' > /home/sprite/greeting.txt"
+sprite exec -- bash -c "echo 'Hello from my persistent Sprite!' > /home/sprite/greeting.txt"
 
 # Disconnect, get coffee, come back later...
 # Everything is still there!
-sprite exec cat /home/sprite/greeting.txt
-sprite exec python -c "import requests; print(requests.__version__)"
+sprite exec -- cat /home/sprite/greeting.txt
+sprite exec -- python -c "import requests; print(requests.__version__)"
 ```
 
 Unlike containers that reset on each run, your Sprite keeps your installed packages, files, and entire filesystem intact.
@@ -132,7 +132,7 @@ sprite url
 Then start a simple Python server:
 
 ```bash
-sprite exec python -m http.server 8080
+sprite exec -- python -m http.server 8080
 ```
 
 Visit the URL in your browser—you'll see Python's directory listing page. Press `Ctrl+C` to stop the server when you're done. Your Sprite automatically routes HTTP traffic to port 8080 and wakes up to handle requests.

--- a/src/content/docs/working-with-sprites.mdx
+++ b/src/content/docs/working-with-sprites.mdx
@@ -20,9 +20,9 @@ Sprites give you three main ways to interact:
 Run a single command, wait for it to finish, get the output. Perfect for scripts, package installs, or quick checks.
 
 ```bash
-sprite exec ls -la
-sprite exec npm install express
-sprite exec -tty vim
+sprite exec -- ls -la
+sprite exec -- npm install express
+sprite exec --tty -- vim
 ```
 
 - Blocks until the command completes
@@ -48,7 +48,7 @@ sprite console
 All TTY sessions are automatically detachable. Start a command, disconnect with `Ctrl+\`, and reattach later. Great for dev servers, long builds, or background processes.
 
 ```bash
-sprite exec -tty npm run dev     # start a TTY session
+sprite exec --tty -- npm run dev # start a TTY session
 # Press Ctrl+\ to detach
 
 sprite sessions list             # list running sessions
@@ -155,9 +155,9 @@ Sprites run Ubuntu 25.10 with common tools preinstalled:
 Install packages like you would locally:
 
 ```bash
-sprite exec pip install pandas numpy
-sprite exec npm install -g typescript
-sprite exec cargo install ripgrep
+sprite exec -- pip install pandas numpy
+sprite exec -- npm install -g typescript
+sprite exec -- cargo install ripgrep
 ```
 
 They persist across hibernation. No rebuilds needed.
@@ -166,7 +166,7 @@ They persist across hibernation. No rebuilds needed.
 **Storage space**: Each Sprite has 100 GB of persistent storage. Check usage with:
 
 ```bash
-sprite exec df -h
+sprite exec -- df -h
 ```
 </Callout>
 
@@ -179,7 +179,7 @@ sprite exec df -h
 ```bash
 sprite use my-sprite
 # Now all commands target this sprite
-sprite exec echo "hello world"
+sprite exec -- echo "hello world"
 ```
 
 ### List and Filter
@@ -266,8 +266,8 @@ sudo dnf install fuse-sshfs
 **Authorize your SSH public keys:**
 
 ```bash
-sprite exec mkdir -p .ssh
-cat ~/.ssh/id_*.pub | sprite exec tee -a .ssh/authorized_keys
+sprite exec -- mkdir -p .ssh
+cat ~/.ssh/id_*.pub | sprite exec -- tee -a .ssh/authorized_keys
 ```
 
 **Add this helper to your shell config:**
@@ -311,16 +311,16 @@ umount /tmp/sprite-mount
 - [Contact support](https://fly.io/dashboard/support) if persistent
 
 **Storage full:**
-- Clean up files: `sprite exec bash -c "du -sh /home/sprite/*"`
+- Clean up files: `sprite exec -- bash -c "du -sh /home/sprite/*"`
 - Delete old checkpoints
 - Create a new Sprite for additional workloads
 
 **Quick debugging:**
 
 ```bash
-sprite exec ps aux      # running processes
-sprite exec df -h       # disk space
-sprite exec free -h     # memory usage
+sprite exec -- ps aux   # running processes
+sprite exec -- df -h    # disk space
+sprite exec -- free -h  # memory usage
 ```
 
 ---


### PR DESCRIPTION
## Summary

Updates `sprite exec` examples in the public docs to use the `--` separator between sprite's own flags and the command's args.

Reported as #164. Examples like `sprite exec ls -la` fail with `unknown shorthand flag: 'l' in -la` because cobra's flag parser keeps consuming flags after the positional command. The fix is `sprite exec -- ls -la`. This matches the convention adopted upstream (the `sprite exec --help` examples and usage line were updated to show `--` in the next rc).

## Changes

- `quickstart.mdx`: every `sprite exec` example uses `--`.
- `working-with-sprites.mdx`: every `sprite exec` example uses `--`. Deprecated `-tty` shorthand swapped to `--tty -- <cmd>`.

## Tests

Tested all commands against a live Sprite running `rc43` version of the CLI

Closes #164.
Closes #180 (duplicate report, same root cause).