### PR TITLE
Add typed publishedDate and author frontmatter fields

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -11,6 +11,9 @@ export const collections = {
         // badge prefers this over git history, so a rewritten older page can
         // be re-flagged as new. See src/lib/sidebar.ts.
         publishedDate: z.coerce.date().optional(),
+        // Author of the page (e.g. a GitHub username). Not displayed; recorded
+        // for attribution and available to components later.
+        author: z.string().optional(),
       }),
     }),
   }),

--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -1,7 +1,17 @@
-import { defineCollection } from 'astro:content';
+import { defineCollection, z } from 'astro:content';
 import { docsLoader } from '@astrojs/starlight/loaders';
 import { docsSchema } from '@astrojs/starlight/schema';
 
 export const collections = {
-  docs: defineCollection({ loader: docsLoader(), schema: docsSchema() }),
+  docs: defineCollection({
+    loader: docsLoader(),
+    schema: docsSchema({
+      extend: z.object({
+        // Date a page was first published or republished. The sidebar "New"
+        // badge prefers this over git history, so a rewritten older page can
+        // be re-flagged as new. See src/lib/sidebar.ts.
+        publishedDate: z.coerce.date().optional(),
+      }),
+    }),
+  }),
 };

--- a/src/content/docs/concepts/services.mdx
+++ b/src/content/docs/concepts/services.mdx
@@ -2,6 +2,7 @@
 title: Services
 description: Processes the Sprite runtime starts at boot, restarts when they crash, and can wire to your Sprite's URL
 publishedDate: 2026-06-02
+author: kcmartin
 ---
 
 import { Callout, LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/concepts/services.mdx
+++ b/src/content/docs/concepts/services.mdx
@@ -1,6 +1,7 @@
 ---
 title: Services
 description: Processes the Sprite runtime starts at boot, restarts when they crash, and can wire to your Sprite's URL
+publishedDate: 2026-06-02
 ---
 
 import { Callout, LinkCard, CardGrid } from '@/components/react';

--- a/src/content/docs/keeping-sprites-running.mdx
+++ b/src/content/docs/keeping-sprites-running.mdx
@@ -1,6 +1,7 @@
 ---
 title: Keeping a Sprite Running
 description: Use the Tasks API to hold a Sprite open while an agent or other long-lived process is doing work
+author: kcmartin
 ---
 
 A Sprite pauses in two stages. It first goes `warm`: compute billing stops, the VM suspends, and the next inbound HTTP request wakes it in 100–500ms with process state preserved. If the Sprite stays idle long enough it transitions to `cold`. In-memory state is dropped and the next wake takes 1–2s.

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -15,7 +15,7 @@ interface SidebarBadge {
 // Configuration for badge thresholds
 const BADGE_CONFIG = {
   // Show "New" badge for content published within this many days
-  newThresholdDays: 3,
+  newThresholdDays: 14,
   // Show "Updated" badge for content updated within this many days
   updatedThresholdDays: 0,
 };

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -1,4 +1,5 @@
 import { execSync } from 'node:child_process';
+import { readFileSync } from 'node:fs';
 import path from 'node:path';
 import type { StarlightUserConfig } from '@astrojs/starlight/types';
 
@@ -37,6 +38,26 @@ function getGitDate(filePath: string, mode: 'first' | 'last'): Date | null {
 }
 
 /**
+ * Read the optional `publishedDate` frontmatter field from a doc. Lets an
+ * older file that was rewritten be re-flagged as new, since git only knows
+ * when the file first appeared, not when it was (re)published.
+ */
+function getPublishedDate(filePath: string): Date | null {
+  try {
+    const source = readFileSync(filePath, 'utf-8');
+    const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+    if (!frontmatter) return null;
+    const field = frontmatter[1].match(/^publishedDate:\s*(.+)$/m);
+    if (!field) return null;
+    const value = field[1].trim().replace(/^['"]|['"]$/g, '');
+    const date = new Date(value);
+    return Number.isNaN(date.getTime()) ? null : date;
+  } catch {
+    return null;
+  }
+}
+
+/**
  * Compute the appropriate badge for a doc based on its git history
  */
 function computeBadge(slug: string): SidebarBadge | undefined {
@@ -44,7 +65,10 @@ function computeBadge(slug: string): SidebarBadge | undefined {
   const fileName = slug === 'index' ? 'index.mdx' : `${slug}.mdx`;
   const filePath = path.join(docsDir, fileName);
 
-  const publishDate = getGitDate(filePath, 'first');
+  // Prefer an explicit `publishedDate` from frontmatter; fall back to the date
+  // the file first landed in git.
+  const publishDate =
+    getPublishedDate(filePath) ?? getGitDate(filePath, 'first');
   if (!publishDate) return undefined;
 
   // "New" takes priority


### PR DESCRIPTION
## What

Two related additions to the docs content schema, both optional typed frontmatter fields.

### publishedDate + the New badge

The sidebar "New" badge keyed off the date a file first appeared in git (`git log --diff-filter=A | tail -1`). That works for genuinely new files, but a page that has existed in the repo for a while and was later rewritten and published, like the Services concept page, keeps its original add date and never re-flags as new.

- Add an optional `publishedDate` field to the docs schema (`docsSchema({ extend: ... })`).
- `computeBadge` in `src/lib/sidebar.ts` now prefers `publishedDate` from frontmatter and falls back to the git first-add date when it's absent.
- Set `publishedDate: 2026-06-02` on the Services page so it shows the New badge.
- Widen the New badge window from 3 days to two weeks (`newThresholdDays`).

### author

- Add an optional `author` field to the same schema. Not displayed on pages; recorded for attribution and available to components later.
- Set `author: kcmartin` on the Services and Keeping a Sprite Running pages.

Both fields are optional, so every existing page keeps its current behavior.