### PR TITLE
Rewrite and publish Checkpoints concept page for rc44

### DIFF
--- a/src/content/docs/concepts/checkpoints.mdx
+++ b/src/content/docs/concepts/checkpoints.mdx
@@ -61,6 +61,18 @@ The last five checkpoints are mounted read-only at `/.sprite/checkpoints/` insid
 diff /.sprite/checkpoints/v34/etc/hosts /etc/hosts
 ```
 
+## Automatic checkpoints
+
+Alongside the checkpoints you take by hand, the platform creates its own in the background as you work. They're tagged automatic and given `auto-` IDs, so they stay separate from your `v0`, `v1`, `v2` series and never consume a version number.
+
+They're hidden by default. List them with `--include-auto`:
+
+```bash
+sprite checkpoint list --include-auto
+```
+
+You restore one exactly like any other checkpoint, by ID. Treat them as a safety net, not a plan: they carry no comment describing what they captured, and older ones are pruned over time. For anything you specifically want to be able to return to, take your own checkpoint with a comment.
+
 ## Checkpointing from inside the Sprite
 
 Agents and scripts running inside a Sprite can manage their own checkpoints, which is what makes them useful for unattended work: snapshot before a risky step, restore if it fails, all without anything outside the Sprite coordinating it.

--- a/src/content/docs/concepts/checkpoints.mdx
+++ b/src/content/docs/concepts/checkpoints.mdx
@@ -9,7 +9,7 @@ import { Callout, LinkCard, CardGrid } from '@/components/react';
 
 Persistence keeps your filesystem across pauses on its own: you don't ask for it, and it's always there. A checkpoint is the other half. It's a save point you create on purpose, a snapshot of the filesystem at one moment that you can return to later.
 
-Reach for one before anything you might want to undo: a dependency upgrade, a destructive refactor, an experiment an agent runs unattended. Take the checkpoint, do the risky thing, and if it goes wrong, restore.
+Reach for a checkpoint before anything you might want to undo: a dependency upgrade, a destructive refactor, an experiment an agent runs unattended. Take the checkpoint, do the risky thing, and if it goes wrong, you can restore.
 
 ## What a checkpoint captures
 

--- a/src/content/docs/concepts/checkpoints.mdx
+++ b/src/content/docs/concepts/checkpoints.mdx
@@ -1,41 +1,34 @@
 ---
 title: Checkpoints
-description: Save and restore Sprite state with checkpoints
-draft: true
+description: Save a Sprite's filesystem at a point in time and roll back to it later. The deliberate save point that complements automatic persistence
+publishedDate: 2026-06-23
+author: kcmartin
 ---
 
-import { Tabs, TabItem } from '@astrojs/starlight/components';
-import { Snippet, LinkCard, CardGrid, Callout } from '@/components/react';
+import { Callout, LinkCard, CardGrid } from '@/components/react';
 
-**Sprites are programmable Linux environments you can spin up, script, and share. Checkpoints let you save a Sprite's entire state and bring it back later.** They capture persistent state: your filesystem, installed packages, environment config, dotfiles. They don't include running processes, network connections, or anything in memory.
+Persistence keeps your filesystem across pauses on its own: you don't ask for it, and it's always there. A checkpoint is the other half. It's a save point you create on purpose, a snapshot of the filesystem at one moment that you can return to later.
 
-They're fast to create, safe to restore, and useful anywhere you'd want a clean slate or an undo button. This guide walks through how they work and how to use them in your tooling.
+Reach for one before anything you might want to undo: a dependency upgrade, a destructive refactor, an experiment an agent runs unattended. Take the checkpoint, do the risky thing, and if it goes wrong, restore.
 
-## What is a Checkpoint?
+## What a checkpoint captures
 
-A checkpoint is a snapshot of your Sprite's persistent state. It includes:
+A checkpoint snapshots the writable filesystem overlay: everything you've added on top of the base image. It does not touch the base image itself, and it does not capture anything that only lives in memory.
 
-- **Complete filesystem** - All files, directories, and data
-- **Installed packages** -  System and language-specific packages
-- **Configuration files** - Environment setup sand dotfiles
-- **Services and policies** - Any services or network policies you've configured
+| Captured | Not captured |
+|----------|--------------|
+| Files and directories | Running processes |
+| Installed packages | In-memory state |
+| Config files and dotfiles | Open network connections |
+| Databases on disk (SQLite, etc.) | |
 
-Creating a checkpoint takes about 300ms and doesn't interrupt the Sprite. It keeps running while the snapshot is taken, so you can keep working.
+This is the same line [Lifecycle and Persistence](/concepts/lifecycle) draws between disk and memory: disk is in the snapshot, memory is not. After a restore, [Services](/concepts/services) come back from their on-disk definitions the way they do after a cold wake. A process you started by hand does not.
 
-Checkpoints don't include:
+## Creating a checkpoint
 
-- Running processes (services are reconfigured, not snapshotted and you'll need to restart those after restore)
-- Network connections
-- Anything in memory
-
-Think of checkpoints as a fast, copy-on-write backup of your environment. They're stored in object storage and can be listed, restored, or deleted later.
-
-## Creating a Checkpoint
-
-Checkpoints are fast to create and don't interrupt your running Sprite. You can make one from the CLI in a single command, including an optional descriptive comment. This takes about 300ms and returns a versioned ID.
+One command snapshots the current state and returns a versioned ID. Add a comment so the ID means something later.
 
 ```bash
-# Create a checkpoint of the current sprite with a descriptive comment
 sprite checkpoint create --comment "Clean Python 3.11 + Node 20 setup"
 ```
 
@@ -43,579 +36,112 @@ sprite checkpoint create --comment "Clean Python 3.11 + Node 20 setup"
 Checkpoint created: v1
 ```
 
-If you're automating this in code, the Go, JavaScript and Elixir SDKs support streaming progress. You'll receive real-time updates as the checkpoint is built, which is handy for long-running environments or instrumentation.
+It runs copy-on-write, so it's fast and doesn't interrupt the Sprite. Work keeps going while the snapshot is taken. IDs are sequential (`v0`, `v1`, `v2`, and so on). For the full command surface, including `list`, `info`, and `delete`, see the [CLI Commands reference](/cli/commands#checkpoints).
 
-<Tabs>
-<TabItem label="Go">
-```go
-ctx := context.Background()
+## Restoring a checkpoint
 
-// Create a checkpoint
-stream, err := sprite.CreateCheckpoint(ctx)
-if err != nil {
-    log.Fatal(err)
-}
-defer stream.Close()
+Restoring replaces the writable overlay with the saved state and restarts the environment. The base image is untouched.
 
-// Process streaming progress messages
-stream.ProcessAll(func(msg *sprites.StreamMessage) error {
-    fmt.Println(msg.Data)
-    return nil
-})
-```
-</TabItem>
-<TabItem label="JavaScript">
-```javascript
-// Create a checkpoint
-const response = await sprite.createCheckpoint();
-
-// Process NDJSON stream
-const reader = response.body.getReader();
-const decoder = new TextDecoder();
-while (true) {
-  const { done, value } = await reader.read();
-  if (done) break;
-  console.log(decoder.decode(value));
-}
-```
-</TabItem>
-<TabItem label="Elixir">
-```elixir
-# Create a checkpoint
-{:ok, messages} = Sprites.create_checkpoint(sprite, comment: "My checkpoint")
-
-# Process streaming progress messages
-Enum.each(messages, fn
-  %{"status" => "complete", "id" => id} -> IO.puts("Checkpoint created: #{id}")
-  %{"type" => "info", "data" => data} -> IO.puts(data)
-  _ -> :ok
-end)
-```
-</TabItem>
-</Tabs>
-
-## Restoring from a Checkpoint
-
-Restoring from a checkpoint replaces your Sprite's current filesystem with the saved snapshot. It stops any running processes and restarts the environment with the restored state. Note that new processes need to be started manually.
-
-If you're using the SDKs, restore works like create, it's a streamed operation that sends progress messages as it runs.
-
-To restore from a checkpoint:
-
-<Tabs>
-<TabItem label="CLI">
 ```bash
-# Restore from a checkpoint
 sprite restore v1
 ```
-</TabItem>
-<TabItem label="Go">
-```go
-ctx := context.Background()
 
-stream, err := sprite.RestoreCheckpoint(ctx, "v1")
-if err != nil {
-    log.Fatal(err)
-}
-defer stream.Close()
+`sprite restore v1` is the alias for `sprite checkpoint restore v1`. The restore is asynchronous: the command returns right away, the environment restarts, and active sessions are terminated. A following `sprite exec` automatically retries while the Sprite is still coming back up.
 
-// Process streaming progress messages
-stream.ProcessAll(func(msg *sprites.StreamMessage) error {
-    fmt.Println(msg.Data)
-    return nil
-})
-```
-</TabItem>
-<TabItem label="JavaScript">
-```javascript
-const response = await sprite.restoreCheckpoint("v1");
-
-// Process NDJSON stream
-const reader = response.body.getReader();
-const decoder = new TextDecoder();
-while (true) {
-  const { done, value } = await reader.read();
-  if (done) break;
-  console.log(decoder.decode(value));
-}
-```
-</TabItem>
-<TabItem label="Elixir">
-```elixir
-{:ok, messages} = Sprites.restore_checkpoint(sprite, "v1")
-
-# Process streaming progress messages
-Enum.each(messages, fn
-  %{"status" => "complete"} -> IO.puts("Restore complete")
-  %{"type" => "info", "data" => data} -> IO.puts(data)
-  _ -> :ok
-end)
-```
-</TabItem>
-</Tabs>
-
-### Restore Considerationss
-
-- **Performance** - Restores are fast, typically completing in under a second
-- **Destructive operation** - Current state is replaced (but backed up automatically)
-- **Process restart** - All running processes are terminated
-- **CLI retry** - Subsequent `sprite exec` commands automatically retry if the sprite is still restarting
-
-## Managing Checkpoints
-
-Here are some additional common ways to interact and mange Checkpoings.
-
-### List Checkpoints
-
-You can list all checkpoints for the current Sprite:
-
-<Tabs>
-<TabItem label="CLI">
-```bash
-sprite checkpoint list
-```
-
-```output
-ID                             CREATED             COMMENT
------------------------------- ------------------- ------------------------
-v1                             2024-01-15 10:30:00 After npm install
-v0                             2024-01-14 15:45:00 Base (clean) state
-```
-</TabItem>
-<TabItem label="Go">
-```go
-ctx := context.Background()
-
-checkpoints, err := sprite.ListCheckpoints(ctx, "")
-if err != nil {
-    log.Fatal(err)
-}
-
-for _, cp := range checkpoints {
-    fmt.Printf("%s  %s  %s\n", cp.ID, cp.CreateTime.Format(time.RFC3339), cp.Comment)
-}
-```
-</TabItem>
-<TabItem label="JavaScript">
-```javascript
-const checkpoints = await sprite.listCheckpoints();
-
-for (const cp of checkpoints) {
-  console.log(`${cp.id}  ${cp.createTime.toISOString()}  ${cp.comment}`);
-}
-```
-</TabItem>
-<TabItem label="Elixir">
-```elixir
-{:ok, checkpoints} = Sprites.list_checkpoints(sprite)
-
-for cp <- checkpoints do
-  IO.puts("#{cp.id}  #{cp.create_time}  #{cp.comment}")
-end
-```
-</TabItem>
-</Tabs>
-
-### Checkpoint Information
-
-To get details about a specific checkpoint:
-
-<Tabs>
-<TabItem label="CLI">
-```bash
-sprite checkpoint info v1
-```
-
-```output
-ID: v1
-Created: 2024-01-15T10:30:00Z
-Comment: After npm install
-History: (none)
-```
-</TabItem>
-<TabItem label="Go">
-```go
-ctx := context.Background()
-
-cp, err := sprite.GetCheckpoint(ctx, "v1")
-if err != nil {
-    log.Fatal(err)
-}
-
-fmt.Printf("ID: %s\n", cp.ID)
-fmt.Printf("Created: %s\n", cp.CreateTime.Format(time.RFC3339))
-fmt.Printf("Comment: %s\n", cp.Comment)
-```
-</TabItem>
-<TabItem label="JavaScript">
-```javascript
-const cp = await sprite.getCheckpoint("v1");
-
-console.log(`ID: ${cp.id}`);
-console.log(`Created: ${cp.createTime.toISOString()}`);
-console.log(`Comment: ${cp.comment}`);
-```
-</TabItem>
-<TabItem label="Elixir">
-```elixir
-{:ok, cp} = Sprites.get_checkpoint(sprite, "v1")
-
-IO.puts("ID: #{cp.id}")
-IO.puts("Created: #{cp.create_time}")
-IO.puts("Comment: #{cp.comment}")
-```
-</TabItem>
-</Tabs>
-
-### Deleting Checkpoints
-
-You can delete individual checkpoints by their ID. Deleted checkpoints cannot be recovered.
-
-<Tabs>
-<TabItem label="CLI">
-```bash
-# Delete a specific checkpoint
-sprite checkpoint delete v3
-```
-
-```output
-Deleted
-```
-</TabItem>
-</Tabs>
-
-<Callout type="warning" title="Delete Restrictions" client:load>
-You cannot delete the currently active checkpoint. Attempting to do so returns an error:
-
-```bash
-sprite checkpoint delete v2
-```
-
-```output
-Error: cannot delete active checkpoint
-```
-
-To delete an active checkpoint, first restore to a different checkpoint, then delete the original.
+<Callout type="warning" title="Restore is destructive. Checkpoint first.">
+Restoring overwrites your current filesystem with the checkpoint's, and the state you replace is not backed up for you. If there's unsaved work you want to keep, create a checkpoint before you restore. Once the restore runs, the previous state is gone unless you captured it.
 </Callout>
 
-### Cleanup Considerations
+## Browsing without restoring
 
-- **Deleted checkpoints cannot be recovered** - Make sure you don't need it before deleting
-- **Storage costs decrease immediately** - Billing stops once the checkpoint is deleted
-- **Keep at least one stable checkpoint** - Always maintain a known-good fallback
-- **Review old checkpoints periodically** - Remove unused checkpoints to manage storage costs
-
-## Manage Checkpoints with the API Inside Your Sprite
-
-You can create and restore checkpoints from within the Sprite itself using its internal API. This is useful for automation, error recovery, and self-managing agents like LLMs.
-
-
-### Using sprite-env
-
-The `sprite-env` CLI provides a straightforward way to interact with the internal checkpoint API:
+The last five checkpoints are mounted read-only at `/.sprite/checkpoints/` inside the Sprite. You can read or diff a previous state without restoring it, which is the quick way to check what changed before you decide to roll back.
 
 ```bash
-# List all checkpoints
+# Compare a file against how it looked in v34
+diff /.sprite/checkpoints/v34/etc/hosts /etc/hosts
+```
+
+## Checkpointing from inside the Sprite
+
+Agents and scripts running inside a Sprite can manage their own checkpoints, which is what makes them useful for unattended work: snapshot before a risky step, restore if it fails, all without anything outside the Sprite coordinating it.
+
+The `sprite-env` CLI is the simplest path:
+
+```bash
+sprite-env checkpoints create --comment "before migration"
 sprite-env checkpoints list
-
-# Create a new checkpoint (streams progress)
-sprite-env checkpoints create
-
-# Restore from a checkpoint
-sprite-env checkpoints restore v1
-```
-
-### Direct API Access
-
-If you prefer to use the internal API with curl:
-
-```bash
-# List checkpoints
-curl --unix-socket /.sprite/api.sock \
-  -H "Content-Type: application/json" \
-  http://sprite/v1/checkpoints
-
-# Create checkpoint
-curl --unix-socket /.sprite/api.sock \
-  -H "Content-Type: application/json" \
-  -X POST http://sprite/v1/checkpoint
-```
-
-### Checkpoint Creation Response
-
-Creating a checkpoint streams progress in NDJSON format:
-
-```json
-{"status": "starting", "message": "Creating checkpoint..."}
-{"status": "progress", "percent": 50}
-{"status": "complete", "id": "v3"}
-```
-
-### Restore Behavior
-
-Restoring a checkpoint resets the Sprite's filesystem to the saved state and restarts the environment. The restore request returns an HTTP 202 (Accepted) immediately and does not wait for completion, since the connection will close during the restart.
-
-```bash
-# This returns immediately, then the sprite restarts with restored state
-sprite-env checkpoints restore v1
-```
-
-This operation replaces the current state with the checkpoint. Running processes will not persist.
-
-### Self-Checkpointing with LLMs
-
-If you're running an agent or script that modifies the environment, it can use sprite-env or write to`/.sprite/llm.txt` to create a checkpoint before making changes.
-
-```bash
-# Before risky operations
-sprite-env checkpoints create
-```
-
-```output
-{"status": "complete", "id": "v4"}
-```
-
-```bash
-# Try something risky...
-rm -rf node_modules && npm install
-
-# If things go wrong, restore
 sprite-env checkpoints restore v4
 ```
 
-This allows autonomous tools to recover gracefully from failed experiments.
-
-
-
-## Checkpoint Storage
-
-Checkpoints are stored in durable object storage using [Tigris Standard tier](https://www.tigrisdata.com/docs/objects/tiers/#standard-tier):
-
-- **Copy-on-write** - Only blocks that have changed are copied, keeping incremental checkpoints small
-- **Geographically redundant** - Data replicated across regions
-- **Highly durable** - High durability, availability and performance for frequently accessed data
-- **Compressed** - Efficient storage usage
-
-### Storage Costs
-
-Checkpoints are billed as regular storage at $0.50/GB/month. Because of copy-on-write, incremental checkpoints don't use much space—you're only billed for changed blocks. See [Billing](/reference/billing) for details.
-
-### Browsing Checkpoints
-
-The last 5 checkpoints are mounted read-only at `/.sprite/checkpoints/` inside your Sprite, allowing you to browse or diff previous states without restoring.
-
-## Common Patterns
-
-Checkpoints make it easier to standardize environments, test changes safely, and recover quickly when things break. Here are a few ways teams are using them in practice.
-
-### Environment Templates
-
-You can use a checkpoint as a clean baseline for new projects or teammates. Set up a Sprite with all the tools and configs you want, checkpoint it, and reuse it as needed.
+Or talk to the management socket directly. `GET /v1/checkpoints` lists them; `POST /v1/checkpoint` creates one and streams progress as NDJSON.
 
 ```bash
-# Create the baseline environment
-sprite create gold-standard
-sprite exec "install-base-tools.sh"
-sprite exec "configure-defaults.sh"
-
-# Save it in a checkpoint
-sprite checkpoint create --comment "Gold standard v1.0"
-
-# Start a new project from the same base
-sprite use gold-standard
-sprite restore v1  # Start from identical baseline
+curl --unix-socket /.sprite/api.sock \
+     -H "Content-Type: application/json" \
+     http://sprite/v1/checkpoints
 ```
 
-### Automated Checkpointing in Scripts
-
-Checkpoints are fast enough to include in regular automation. For example, you can create one just before a deployment, so you can roll back quickly if something fails.
+The self-checkpointing pattern is the payoff: checkpoint before something risky, run it, restore on failure.
 
 ```bash
-#!/bin/bash
-# deployment.sh - Safe deployment with automatic rollback
+sprite-env checkpoints create --comment "pre-experiment"
 
-# Create safety checkpoint
-sprite checkpoint create --comment "Pre-deploy $(date +%Y%m%d-%H%M)"
+# Try something that might not work
+rm -rf node_modules && npm install
 
-# Try deployment
-if ! sprite exec "deploy.sh"; then
-  echo "Deployment failed, rolling back..."
-  sprite restore v$(sprite checkpoint list | head -2 | tail -1 | awk '{print $1}')
-  exit 1
-fi
-
-echo "Deployment successful"
+# If it broke, roll back to the checkpoint above
+sprite-env checkpoints restore v4
 ```
 
-### A/B Testing Configurations
+The behavior an agent relies on is documented inside every Sprite at `/.sprite/llm.txt`, which is read-only reference, not a control file.
 
-You can use checkpoints to fan out from a common base config. This makes it easy to set up multiple test environments with minimal drift.
+## Checkpoints are not version control
+
+A checkpoint captures environment state, not code history. It's a fast undo for setup, config, and the moving parts around your work. It is not a substitute for Git, which is where your code and its history belong. Use both: commit your code, checkpoint the environment around it.
 
 ```bash
-# Create base configuration
-sprite use base-config
-sprite exec "setup-base.sh"
-sprite checkpoint create --comment "Base config for A/B test"
-
-# Create variant A
-sprite create variant-a
-sprite restore v1
-sprite exec "apply-config-a.sh"
-
-# Create variant B
-sprite create variant-b
-sprite restore v1
-sprite exec "apply-config-b.sh"
-
-# Run tests in parallel
-sprite use variant-a && sprite exec "run-tests.sh" &
-sprite use variant-b && sprite exec "run-tests.sh" &
-wait
+git commit -am "Save progress"
+sprite checkpoint create --comment "tests green"
 ```
 
-## Best Practices
+## Storage and cleanup
 
-Checkpoints are lightweight and fast, but they're not magic. Here are a few practices to help you use them effectively.
+Checkpoints live in durable object storage and are copy-on-write: a new checkpoint only stores the blocks that changed since the last one, so incremental snapshots stay small. You're billed for the blocks actually kept, and deleting a checkpoint frees that space right away.
 
-### Using Comments
+A couple of rules worth knowing:
 
-Checkpoints use sequential version IDs (v0, v1, v2, etc.), so adding a descriptive comment makes it easier to remember what each one is for.
+- You can't delete the checkpoint you're currently on. Restore to another one first, then delete it.
+- Keep at least one known-good checkpoint as a fallback, and prune the rest periodically so old state doesn't pile up.
 
-<Tabs>
-<TabItem label="CLI">
-```bash
-# Create checkpoint with a descriptive comment
-sprite checkpoint create --comment "Clean Python 3.11 + Node 20 setup"
-```
-
-```output
-Checkpoint created: v1
-```
-
-```bash
-# List checkpoints to see comments
-sprite checkpoint list
-```
-
-```output
-ID    CREATED              COMMENT
-v1    2024-01-15 10:30:00  Clean Python 3.11 + Node 20 setup
-```
-</TabItem>
-<TabItem label="Go">
-```go
-ctx := context.Background()
-
-// Create checkpoint with comment
-stream, err := sprite.CreateCheckpointWithComment(ctx, "Clean Python 3.11 + Node 20 setup")
-if err != nil {
-    log.Fatal(err)
-}
-defer stream.Close()
-stream.ProcessAll(func(msg *sprites.StreamMessage) error {
-    fmt.Println(msg.Data)
-    return nil
-})
-```
-</TabItem>
-<TabItem label="JavaScript">
-```javascript
-// Create checkpoint with comment
-const response = await sprite.createCheckpoint("Clean Python 3.11 + Node 20 setup");
-
-const reader = response.body.getReader();
-const decoder = new TextDecoder();
-while (true) {
-  const { done, value } = await reader.read();
-  if (done) break;
-  console.log(decoder.decode(value));
-}
-```
-</TabItem>
-<TabItem label="Elixir">
-```elixir
-# Create checkpoint with comment
-{:ok, messages} = Sprites.create_checkpoint(sprite,
-  comment: "Clean Python 3.11 + Node 20 setup"
-)
-
-Enum.each(messages, fn
-  %{"status" => "complete", "id" => id} -> IO.puts("Checkpoint created: #{id}")
-  _ -> :ok
-end)
-```
-</TabItem>
-</Tabs>
-
-### When to Create Checkpoints
-
-Checkpoints are fast enough to use regularly. Some good times to create one:
-
-- Daily during active development
-- Before upgrades, refactors, experiments, or other risky operations
-- After milestones (when tests pass or a feature is complete)
-
-### Clean Up Old Checkpoints
-
-Checkpoints take up space. You don't need to keep every one.
-
-```bash
-# List all checkpoints
-sprite checkpoint list
-
-# Delete checkpoints you no longer need
-sprite checkpoint delete v1
-sprite checkpoint delete v2
-```
-
-See [Deleting Checkpoints](#deleting-checkpoints) for details.
-
-### Integrate with LLMs
-
-Point your LLM at `/.sprite/llm.txt` inside your Sprite and it can manage checkpoints for you programmatically to create snapshots before risky operations and restoring when things go wrong. This makes it easier to recover from failed experiments without external coordination.
-
-### Use Git for Code...Don't Rely on Checkpoints Alone
-
-Checkpoints capture environment state, not version history. They're not a replacement for Git. Use checkpoints for setup, config, and temporary state. Use Git for everything else.
-
-```bash
-# Good: Use both
-sprite exec "git commit -am 'Save progress'"
-sprite checkpoint create
-
-# Bad: Only using checkpoints for code
-sprite checkpoint create  # Don't do this for code changes
-```
-
-## Related Documentation
+## Related documentation
 
 <CardGrid client:load>
   <LinkCard
-    href="/concepts/lifecycle"
-    title="Lifecycle and Persistence"
-    description="Understanding how persistence works"
-    icon="layers"
-    client:load
-  />
-  <LinkCard
-    href="/cli/commands"
+    href="/cli/commands#checkpoints"
     title="CLI Commands"
-    description="Checkpoint and other CLI commands"
+    description="Full reference for sprite checkpoint create, list, info, delete, and restore"
     icon="terminal"
     client:load
   />
   <LinkCard
-    href="/reference/billing"
-    title="Billing"
-    description="Storage costs and pricing details"
-    icon="file-text"
+    href="/concepts/lifecycle"
+    title="Lifecycle and Persistence"
+    description="How automatic persistence keeps your filesystem across pauses"
+    icon="layers"
     client:load
   />
   <LinkCard
     href="/concepts/services"
     title="Services"
-    description="Long-running processes that persist across reboots"
+    description="Processes the runtime brings back after a restore or cold wake"
     icon="cog"
+    client:load
+  />
+  <LinkCard
+    href="/working-with-sprites"
+    title="Working with Sprites"
+    description="Interaction modes and the filesystem in practice"
+    icon="terminal"
     client:load
   />
 </CardGrid>

--- a/src/lib/sidebar.ts
+++ b/src/lib/sidebar.ts
@@ -138,6 +138,7 @@ export const sidebarConfig: SidebarGroup[] = [
   {
     label: 'Concepts',
     items: [
+      { label: 'Checkpoints', slug: 'concepts/checkpoints' },
       { label: 'Connectors', slug: 'concepts/connectors' },
       { label: 'Lifecycle and Persistence', slug: 'concepts/lifecycle' },
       { label: 'Services', slug: 'concepts/services' },

--- a/styles/config/vocabularies/fly-terms/accept.txt
+++ b/styles/config/vocabularies/fly-terms/accept.txt
@@ -178,6 +178,7 @@ JWKS
 JWTs?
 k6
 kerl
+kcmartin
 keypair
 keypairs
 Knex


### PR DESCRIPTION
Rewrites the draft Checkpoints page into a concept hub, matching the Lifecycle and Persistence and Services pages: explain the model, link out for the procedural detail, avoid duplicating the CLI reference.

## What changed
- Reframed the old 600-line "kitchen-sink" draft into a ~150-line concept hub.
- Corrected a real bug: the draft claimed restore backs up the replaced state automatically. It does not. `rc44` restore is destructive, so the page now says to checkpoint first.
- Updated facts for `rc44`: writable-overlay-only snapshot, sequential IDs, async + destructive restore, read-only `/.sprite/checkpoints/` mount, `sprite-env`/socket self-checkpointing, `llm.txt` as read-only reference.
- Dropped the SDK tabs, fake 2024 dates, typos, and the broken delete example.
- Billing covered qualitatively, no price or link (billing page is still draft).
- Published: `publishedDate` + author set, added to the Concepts sidebar.
- Added short section on automated Checkpoints

Command-surface detail stays on the CLI Commands reference; this page links to it.