### PR TITLE
Fix transparent nav bar (restore backdrop-filter blur)

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -515,10 +515,16 @@ pre[data-bash-prompt] > code {
   font-size: 0.875em;
 }
 
+/*
+ * Only the standard `backdrop-filter` is written here; Lightning CSS (via the
+ * Tailwind v4 plugin) adds the `-webkit-` prefix at build time. Do NOT hand-write
+ * `-webkit-backdrop-filter` — a Lightning CSS bug then collapses the pair down to
+ * the webkit-only version, dropping the standard property and leaving the nav bar
+ * transparent in browsers that don't honor the prefixed alias.
+ */
 header.header {
   border-bottom: 1px solid rgba(255, 255, 255, 0.15);
   backdrop-filter: blur(16px) saturate(200%) brightness(1.05);
-  -webkit-backdrop-filter: blur(16px) saturate(200%) brightness(1.05);
   background: rgba(12, 10, 9, 0.4);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.2);
 }
@@ -526,7 +532,6 @@ header.header {
 [data-theme='light'] header.header {
   border-bottom: 1px solid rgba(0, 0, 0, 0.08);
   backdrop-filter: blur(24px) saturate(200%);
-  -webkit-backdrop-filter: blur(24px) saturate(200%);
   background: rgba(255, 255, 255, 0.25);
   box-shadow: 0 4px 30px rgba(0, 0, 0, 0.06), inset 0 0 0 1px rgba(255, 255, 255, 0.5);
 }


### PR DESCRIPTION
## Problem

The nav bar on docs.sprites.dev regressed to **completely transparent**. It wasn't styled that way — the header's `backdrop-filter` blur stopped rendering, leaving only its 40%-opaque background, which the page content shows straight through.

## Root cause

The **deployed** CSS contained only `-webkit-backdrop-filter`; the standard `backdrop-filter` was dropped at build time:

```
header.header{-webkit-backdrop-filter:blur(16px)…;background:#0c0a0966;…}   ← no standard property
```

When both the standard property and a hand-written `-webkit-` prefix are present in source, **Lightning CSS** (pulled in by the Tailwind v4 Vite plugin) collapses the pair down to the webkit-only version. Modern Chromium/Firefox **don't honor `-webkit-backdrop-filter` alone**, so the blur vanished. Verified live:

| applied | computed `backdrop-filter` |
|---|---|
| deployed (webkit-only) | `none` ❌ |
| standard property | `blur(16px)…` ✅ |
| `-webkit-` only | `none` ❌ |

(Compounded by commit `dc5327a`, which removed the opaque fallback background when glassmorphism was added — so with no blur there's nothing left to hide behind.)

## Fix

Write **only** the standard `backdrop-filter` and let Lightning CSS add the `-webkit-` prefix itself. Confirmed a fresh `astro build` now emits **both** properties:

```
header.header{-webkit-backdrop-filter:blur(16px)…;backdrop-filter:blur(16px)…;background:#0c0a0966;…}
```

Added a comment so the prefix isn't re-added by hand and the regression can't silently recur.

## Verification

- Reproduced the Lightning CSS drop against every common browser target, and confirmed writing standard-only yields both properties.
- Built locally and confirmed the header now computes `backdrop-filter: blur(16px) saturate(2) brightness(1.05)`.
- Visually confirmed the frosted-glass nav bar renders (locally verified by the author).

🤖 Generated with [Claude Code](https://claude.com/claude-code)