### PR TITLE
Open external links in new tab with external-link icon

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -4,6 +4,7 @@ import starlight from '@astrojs/starlight';
 import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'astro/config';
 import { sidebarConfig, withBadges } from './src/lib/sidebar';
+import rehypeExternalLinks from './src/plugins/rehype-external-links';
 import rehypeShadcnTable from './src/plugins/rehype-shadcn-table';
 
 // https://astro.build/config
@@ -128,7 +129,7 @@ export default defineConfig({
     sitemap(),
   ],
   markdown: {
-    rehypePlugins: [rehypeShadcnTable],
+    rehypePlugins: [rehypeShadcnTable, rehypeExternalLinks],
   },
   vite: {
     plugins: [tailwindcss()],

--- a/scripts/generate-api-docs.ts
+++ b/scripts/generate-api-docs.ts
@@ -1054,10 +1054,10 @@ Create a token at [sprites.dev/account](https://sprites.dev/account), or generat
 
 For a better developer experience, use our official SDKs:
 
-- [Go ↗](${SDK_REPOS.go})
-- [JavaScript ↗](${SDK_REPOS.javascript})
-- [Python ↗](${SDK_REPOS.python})
-- [Elixir ↗](${SDK_REPOS.elixir})
+- [Go](${SDK_REPOS.go})
+- [JavaScript](${SDK_REPOS.javascript})
+- [Python](${SDK_REPOS.python})
+- [Elixir](${SDK_REPOS.elixir})
 
 ## API Categories
 

--- a/src/plugins/rehype-external-links.ts
+++ b/src/plugins/rehype-external-links.ts
@@ -1,0 +1,94 @@
+/**
+ * Rehype plugin to mark external links in markdown/MDX content.
+ *
+ * External links (absolute http(s) URLs pointing to a different host than the
+ * docs site) are opened in a new tab and get a small "arrow up-right" icon
+ * appended, matching the lucide ArrowUpRight icon used elsewhere in the site.
+ *
+ * Internal links (relative paths, in-page anchors, same-host absolute URLs,
+ * mailto/tel, etc.) are left untouched.
+ */
+import type { Element, Root } from 'hast';
+import { visit } from 'unist-util-visit';
+
+// Host of the docs site; absolute links to this host are treated as internal.
+const SITE_HOST = 'docs.sprites.dev';
+
+function isExternalHref(href: string): boolean {
+  // Protocol-relative URLs, e.g. //example.com/foo
+  if (href.startsWith('//')) {
+    const host = href.slice(2).split('/')[0].toLowerCase();
+    return host !== SITE_HOST;
+  }
+
+  // Absolute http(s) URLs
+  if (/^https?:\/\//i.test(href)) {
+    try {
+      return new URL(href).host.toLowerCase() !== SITE_HOST;
+    } catch {
+      return false;
+    }
+  }
+
+  // Everything else (relative, anchors, mailto:, tel:, …) is internal.
+  return false;
+}
+
+// lucide "arrow-up-right" icon as a hast element (inherits currentColor).
+function externalIcon(): Element {
+  return {
+    type: 'element',
+    tagName: 'svg',
+    properties: {
+      className: ['external-icon'],
+      'aria-hidden': 'true',
+      focusable: 'false',
+      xmlns: 'http://www.w3.org/2000/svg',
+      width: 16,
+      height: 16,
+      viewBox: '0 0 24 24',
+      fill: 'none',
+      stroke: 'currentColor',
+      strokeWidth: 2,
+      strokeLinecap: 'round',
+      strokeLinejoin: 'round',
+    },
+    children: [
+      {
+        type: 'element',
+        tagName: 'path',
+        properties: { d: 'M7 7h10v10' },
+        children: [],
+      },
+      {
+        type: 'element',
+        tagName: 'path',
+        properties: { d: 'M7 17 17 7' },
+        children: [],
+      },
+    ],
+  };
+}
+
+export default function rehypeExternalLinks() {
+  return (tree: Root) => {
+    visit(tree, 'element', (node) => {
+      if (node.tagName !== 'a') return;
+
+      const href = node.properties?.href;
+      if (typeof href !== 'string' || !isExternalHref(href)) return;
+
+      // Guard against double-processing.
+      if (node.properties['data-external']) return;
+
+      node.properties = {
+        ...node.properties,
+        'data-external': true,
+        target: '_blank',
+        rel: 'noopener noreferrer',
+      };
+
+      node.children.push(externalIcon());
+    });
+  };
+}

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -914,6 +914,18 @@ main .sl-markdown-content a:not(.sl-badge, [class*="button"], [class*="btn"], .n
   color: oklch(0.7 0.2 285) !important;
 }
 
+/* External links (marked by rehype-external-links) - small up-right arrow */
+main .sl-markdown-content a[data-external] .external-icon {
+  display: inline-block;
+  width: 0.85em;
+  height: 0.85em;
+  margin-inline-start: 0.15em;
+  vertical-align: baseline;
+  transform: translateY(0.08em);
+  /* Keep the dotted underline off the icon itself */
+  text-decoration: none;
+}
+
 /* Starlight Tabs - shadcn style */
 starlight-tabs [role="tablist"] {
   display: inline-flex;


### PR DESCRIPTION
## What

External links in doc content now open in a new tab and show a small external-link arrow (↗). Internal links are unchanged — no icon, same navigation.

## How

New rehype plugin **`src/plugins/rehype-external-links.ts`** (mirrors the existing `rehype-shadcn-table` pattern), registered in `astro.config.ts`. For each markdown/MDX anchor whose href is an absolute `http(s)`/protocol-relative URL pointing to a host other than `docs.sprites.dev`, it:

- adds `target="_blank"` + `rel="noopener noreferrer"`
- appends a lucide **`ArrowUpRight`** (↗) icon — the same icon `LinkCard` already uses for external links

Everything else (relative paths, in-page `#anchors`, same-host absolute URLs, `mailto:`/`tel:`) is left untouched.

Icon styling lives in `custom.css`: sized `0.85em`, inherits `currentColor` so it turns violet on hover like the link text.

Also removed the now-redundant hand-typed `↗` from the API SDK-library links. Fixed the source of truth (`scripts/generate-api-docs.ts`) so the auto-injected icon doesn't double up. (The generated `index.mdx` files are gitignored and regenerated from that script.)

## Verification

- `astro build` passes; Biome clean on all touched files.
- Screenshotted the live preview:
  - **External** (SDK list + inline "official instructions ↗") → single arrow, opens in new tab, icon inherits hover color.
  - **Internal** ("mounting the filesystem locally") → no icon, unchanged.

Note: this covers links rendered from doc content. Components like `LinkCard` define their own external-link behavior and were already consistent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)