### PR TITLE
Redesign "On this page" ToC with a sliding accent thumb

### DIFF
--- a/astro.config.ts
+++ b/astro.config.ts
@@ -123,6 +123,7 @@ export default defineConfig({
         PageTitle: './src/components/PageTitle.astro',
         SiteTitle: './src/components/SiteTitle.astro',
         Pagination: './src/components/Pagination.astro',
+        TableOfContents: './src/components/TableOfContents.astro',
       },
     }),
     react(),

--- a/src/components/TableOfContents.astro
+++ b/src/components/TableOfContents.astro
@@ -1,0 +1,218 @@
+---
+// Desktop "On this page" table of contents.
+//
+// Overrides Starlight's default TableOfContents so we can own the scroll-spy:
+// Starlight's built-in observer leaves the last section(s) un-highlighted at the
+// bottom of the page and ignores the URL hash, which made the sliding thumb stick
+// on the wrong heading. This version drives both the active-link highlight and the
+// thumb from a single scroll-spy that handles bottom-of-page and honors
+// clicked/hash targets. The mobile ToC keeps using Starlight's component.
+
+const { toc } = Astro.locals.starlightRoute;
+const label = Astro.locals.t('tableOfContents.onThisPage');
+
+// Flatten the heading tree into a single list, keeping depth for indentation.
+type FlatItem = { slug: string; text: string; depth: number };
+function flatten(items: any[], depth = 0, out: FlatItem[] = []): FlatItem[] {
+  for (const item of items) {
+    out.push({ slug: item.slug, text: item.text, depth });
+    if (item.children?.length) flatten(item.children, depth + 1, out);
+  }
+  return out;
+}
+const items = toc ? flatten(toc.items) : [];
+---
+
+{
+  toc && (
+    <div class="sl-toc">
+      <nav aria-labelledby="starlight__on-this-page">
+        <h2 id="starlight__on-this-page">{label}</h2>
+        <ul class="sl-toc-list">
+          {items.map((item) => (
+            <li>
+              <a href={`#${item.slug}`} style={`--depth:${item.depth}`}>
+                {item.text}
+              </a>
+            </li>
+          ))}
+        </ul>
+        <div class="sl-toc-thumb" aria-hidden="true" />
+      </nav>
+    </div>
+  )
+}
+
+<script>
+  let cleanup: Array<() => void> = [];
+
+  function teardown() {
+    cleanup.forEach((fn) => fn());
+    cleanup = [];
+  }
+
+  function initTOC() {
+    teardown();
+
+    const root = document.querySelector('.sl-toc');
+    if (!root) return;
+    const nav = root.querySelector('nav');
+    const list = root.querySelector<HTMLElement>('.sl-toc-list');
+    const thumb = root.querySelector<HTMLElement>('.sl-toc-thumb');
+    if (!nav || !list || !thumb) return;
+
+    const links = Array.from(list.querySelectorAll('a'));
+    if (!links.length) return;
+
+    // Resolve each link to its heading element (null for `#_top` / missing).
+    const headings = links.map((a) => {
+      const id = decodeURIComponent((a.getAttribute('href') || '').slice(1));
+      return id ? document.getElementById(id) : null;
+    });
+
+    // Switch the active heading a little below the sticky header.
+    let offset = 0;
+    const measure = () => {
+      const header = document.querySelector('header');
+      offset = (header ? header.getBoundingClientRect().height : 64) + 24;
+    };
+    measure();
+
+    // Viewport-top of a heading; missing headings (e.g. `#_top`) sit at doc top.
+    const topOf = (el: HTMLElement | null) =>
+      el ? el.getBoundingClientRect().top : -window.scrollY;
+
+    const activeIndex = () => {
+      const de = document.documentElement;
+      // At the bottom of the page, highlight the last heading.
+      if (window.innerHeight + window.scrollY >= de.scrollHeight - 4) {
+        return links.length - 1;
+      }
+      let idx = 0;
+      for (let i = 0; i < headings.length; i++) {
+        if (topOf(headings[i]) <= offset + 1) idx = i;
+        else break;
+      }
+      return idx;
+    };
+
+    const positionThumb = (link: HTMLElement | undefined) => {
+      if (!link) {
+        thumb.style.opacity = '0';
+        return;
+      }
+      const navRect = nav.getBoundingClientRect();
+      const listRect = list.getBoundingClientRect();
+      const r = link.getBoundingClientRect();
+      thumb.style.opacity = '1';
+      thumb.style.left = listRect.left - navRect.left + 'px';
+      thumb.style.height = r.height + 'px';
+      thumb.style.transform = `translateY(${r.top - navRect.top}px)`;
+    };
+
+    let currentIndex = -1;
+    const setActive = (idx: number) => {
+      if (idx !== currentIndex) {
+        links.forEach((a, i) =>
+          i === idx
+            ? a.setAttribute('aria-current', 'true')
+            : a.removeAttribute('aria-current')
+        );
+        currentIndex = idx;
+      }
+      positionThumb(links[idx]);
+    };
+
+    const indexForHash = () => {
+      const h = location.hash;
+      if (!h) return null;
+      const i = links.findIndex((a) => a.getAttribute('href') === h);
+      return i >= 0 ? i : null;
+    };
+
+    // `pinned` holds an explicitly navigated target (click / hash) until the user
+    // scrolls, so the thumb lands on the heading the reader asked for even when
+    // the page can't scroll far enough for scroll-spy to reach it.
+    let pinned: number | null = null;
+
+    const sync = () => {
+      if (pinned != null) positionThumb(links[pinned]);
+      else setActive(activeIndex());
+    };
+
+    // Initial position — suppress the slide-in animation on first paint.
+    thumb.classList.add('sl-toc-thumb--init');
+    const startPin = indexForHash();
+    if (startPin != null) {
+      pinned = startPin;
+      setActive(startPin);
+    } else {
+      setActive(activeIndex());
+    }
+    requestAnimationFrame(() => thumb.classList.remove('sl-toc-thumb--init'));
+
+    // Scroll — rAF-throttled.
+    let ticking = false;
+    const onScroll = () => {
+      if (ticking) return;
+      ticking = true;
+      requestAnimationFrame(() => {
+        ticking = false;
+        sync();
+      });
+    };
+    window.addEventListener('scroll', onScroll, { passive: true });
+    cleanup.push(() => window.removeEventListener('scroll', onScroll));
+
+    const onResize = () => {
+      measure();
+      sync();
+    };
+    window.addEventListener('resize', onResize);
+    cleanup.push(() => window.removeEventListener('resize', onResize));
+
+    // Clicking a link pins it (instant, before the scroll settles).
+    links.forEach((a, i) => {
+      const fn = () => {
+        pinned = i;
+        setActive(i);
+      };
+      a.addEventListener('click', fn);
+      cleanup.push(() => a.removeEventListener('click', fn));
+    });
+
+    // Hash navigation (back/forward, in-page links) pins the target.
+    const onHash = () => {
+      const i = indexForHash();
+      if (i != null) {
+        pinned = i;
+        setActive(i);
+      }
+    };
+    window.addEventListener('hashchange', onHash);
+    cleanup.push(() => window.removeEventListener('hashchange', onHash));
+
+    // A real user scroll releases the pin so scroll-spy resumes.
+    const releaseKeys = new Set([
+      'ArrowDown', 'ArrowUp', 'PageDown', 'PageUp', 'Home', 'End', ' ', 'Spacebar',
+    ]);
+    const release = (e: Event) => {
+      if (e.type === 'keydown' && !releaseKeys.has((e as KeyboardEvent).key)) return;
+      if (pinned != null) {
+        pinned = null;
+        sync();
+      }
+    };
+    ['wheel', 'touchmove', 'keydown'].forEach((ev) => {
+      window.addEventListener(ev, release, { passive: true });
+      cleanup.push(() => window.removeEventListener(ev, release));
+    });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', initTOC);
+  } else {
+    initTOC();
+  }
+  document.addEventListener('astro:page-load', initTOC);
+</script>

--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -849,14 +849,95 @@ h1, h2, h3, h4, h5, h6 {
   color: oklch(0.2 0.02 285);
 }
 
-/* Table of contents in light mode - dark readable text */
-[data-theme='light'] starlight-toc a {
-  color: oklch(0.3 0.02 285) !important;
+/* ─────────────────────────────────────────────────────────────
+   Table of contents ("On this page") — Fumadocs-style rail with a
+   sliding accent thumb. Markup + scroll-spy live in the overridden
+   TableOfContents.astro component; the thumb is positioned in JS.
+   ───────────────────────────────────────────────────────────── */
+
+/* Per-theme colors live in variables so theme overrides never compete with
+   the hover/active state selectors (equal-specificity source-order bugs). */
+.sl-toc {
+  --toc-text: var(--sl-color-gray-3);
+  --toc-text-hover: var(--sl-color-white);
+  --toc-text-active: var(--sl-color-accent);
+  --toc-rail: var(--sl-color-hairline);
+  --toc-thumb: var(--sl-color-accent);
 }
 
-[data-theme='light'] starlight-toc a:hover,
-[data-theme='light'] starlight-toc a[aria-current="true"] {
-  color: oklch(0.45 0.22 285) !important;
+[data-theme='light'] .sl-toc {
+  /* Darker inactive links for readability on white */
+  --toc-text: oklch(0.42 0.015 285);
+}
+
+.sl-toc nav {
+  position: relative;
+}
+
+/* Section label — compact mono terminal-style header */
+.sl-toc nav > h2 {
+  font-family: var(--sl-font-system-mono);
+  font-size: 0.6875rem;
+  font-weight: 600;
+  line-height: 1;
+  letter-spacing: 0.09em;
+  text-transform: uppercase;
+  color: var(--sl-color-gray-2);
+  margin-block-end: 0.75rem;
+}
+
+/* The rail — a faint vertical line running the length of the list */
+.sl-toc-list {
+  position: relative;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  border-inline-start: 2px solid var(--toc-rail);
+}
+
+/* Links — muted by default, brighten on hover, accent when active.
+   Indentation scales with heading depth (--depth set per item). */
+.sl-toc-list a {
+  --toc-indent: calc(var(--depth, 0) * 0.75rem);
+  display: block;
+  padding-block: 0.3rem;
+  padding-inline: calc(0.875rem + var(--toc-indent)) 0.5rem;
+  line-height: 1.4;
+  font-size: 0.8125rem;
+  color: var(--toc-text);
+  text-decoration: none;
+  transition: color 0.15s ease;
+}
+
+.sl-toc-list a:hover {
+  color: var(--toc-text-hover);
+}
+
+.sl-toc-list a[aria-current="true"] {
+  color: var(--toc-text-active);
+  font-weight: 500;
+}
+
+/* The sliding thumb — a bright accent segment layered over the rail,
+   moved/resized to the active heading in JS. */
+.sl-toc-thumb {
+  position: absolute;
+  top: 0;
+  width: 2px;
+  border-radius: 2px;
+  background: var(--toc-thumb);
+  opacity: 0;
+  pointer-events: none;
+  will-change: transform, height;
+  transition:
+    transform 0.24s cubic-bezier(0.4, 0, 0.2, 1),
+    height 0.24s cubic-bezier(0.4, 0, 0.2, 1),
+    opacity 0.15s ease;
+}
+
+/* Suppress the slide-in animation on first paint / page load */
+.sl-toc-thumb--init {
+  transition: none;
 }
 
 /* Header links in light mode */
@@ -1550,8 +1631,8 @@ h2.method-title {
    Full-Width Pages - API Documentation Layout
    ============================================================================ */
 
-/* Hide right sidebar when ToC is disabled (no starlight-toc content) */
-.right-sidebar-container:not(:has(starlight-toc nav)) {
+/* Hide right sidebar when ToC is disabled (no ToC content) */
+.right-sidebar-container:not(:has(.sl-toc nav)) {
   display: none;
 }
 


### PR DESCRIPTION
## What

Restyles the desktop "On this page" table of contents into a Fumadocs-style rail with a sliding accent thumb, and fixes the thumb landing on the wrong heading.

## Changes
- **New override component** `src/components/TableOfContents.astro` (registered in `astro.config.ts`) with a self-contained scroll-spy that:
  - drives both the active-link highlight and a sliding/resizing thumb from a single source,
  - handles bottom-of-page (highlights the last heading),
  - honors clicked/hash targets by pinning them until the reader scrolls,
  - re-initializes across view transitions and tears down its own listeners.
- **Styling** in `src/styles/custom.css`: faint rail, compact uppercase mono label, muted → hover → accent link states, depth-based indentation, and the sliding thumb. Colors run through per-theme CSS variables (green in dark, violet in light) so theme overrides never fight the hover/active state selectors.
- The **mobile ToC** keeps using Starlight's default component.

## Why

Starlight's built-in scroll-spy leaves the last section(s) un-highlighted at the bottom of the page and ignores the URL hash, so the thumb stuck on the wrong heading (e.g. navigating to a near-bottom anchor like `#managing-services-from-outside-the-sprite`). Owning the scroll-spy fixes this and avoids dual-`aria-current` bugs that come from writing the attribute from two sources.

## Testing

Verified against the preview build with a headless browser:
- Navigating to a near-bottom anchor now highlights **that** heading with the thumb aligned (exactly one `aria-current`).
- Scroll-spy tracks correctly top → bottom; bottom of page highlights the last heading.
- Dark (green) and light (violet) active + thumb colors confirmed.

Note: the ToC title is now a compact uppercase mono label (Fumadocs-like) rather than the large mono heading; easy to revert in `custom.css` (`.sl-toc nav > h2`) if the larger title is preferred.

🤖 Generated with [Claude Code](https://claude.com/claude-code)