### PR TITLE
Lift Starlight's .main-pane isolation on pages with hero art

### DIFF
--- a/src/styles/custom.css
+++ b/src/styles/custom.css
@@ -1848,3 +1848,15 @@ h2.method-title {
     font-size: var(--sl-text-sm) !important;
   }
 }
+
+/* Starlight's .main-pane sets isolation: isolate, which traps mix-blend-mode
+   elements inside the pane: their backdrop is the isolated group (transparent),
+   not the page background — the body background and the fixed dark-mode
+   #sprites-bg art paint outside the group, so blending silently no-ops.
+   On pages with hero art (.hero-art images use blend modes to merge their
+   flat black/white backgrounds into the page), lift the isolation so the
+   blend reaches the real backdrop. Scoped via :has() so every other page
+   keeps Starlight's default stacking behavior. */
+.main-pane:has(.hero-art) {
+  isolation: auto;
+}


### PR DESCRIPTION
## Why

Starlight sets `isolation: isolate` on `.main-pane`, which seals the content pane into its own stacking context. Any `mix-blend-mode` element inside it blends against the isolated group's backdrop — which is fully transparent, because the page background (the `<body>` color, and in dark mode the fixed `#sprites-bg` black + green-glow art from `Background.astro`) paints **outside** the group. The blend silently no-ops.

This matters for hero art: the Managed Agents guide (#193) ships theme-conditional hero images whose flat black/white backgrounds are meant to be erased into the page via `screen`/`multiply`. Without this change those images render as hard-edged rectangles.

## What

```css
.main-pane:has(.hero-art) {
  isolation: auto;
}
```

Scoped via `:has(.hero-art)` so only pages that actually ship blend-mode hero art opt out of Starlight's default stacking; everything else (e.g. pages relying on contained z-indexes, like the lifecycle diagram) is untouched.

## Safety

- Pure no-op until a page ships `.hero-art` images — merge order with #193 doesn't matter.
- On the one affected page, content z-index usage was audited: only the expressive-code copy button (`z-index: 2`, contained by its own `position: relative` frame) — nothing that can escape above the navbar.
- Verified by pixel-sampling a live render: with isolation lifted, blend output exactly matches the backdrop on all four hero edges in both themes, and sidebar/main/ToC backdrops stay continuous.

🤖 Generated with [Claude Code](https://claude.com/claude-code)