### PR TITLE
Fix Sprite URL domain: .sprites.app -> .sprites.dev

### DIFF
--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -209,7 +209,7 @@ The default Sprite environment includes:
 
 No default ports are exposed. Start services on any port and access via:
 
-1. **Sprite URL** - `https://sprite-name.sprites.app:PORT`
+1. **Sprite URL** - `https://sprite-name.sprites.dev:PORT`
 2. **Port forwarding** - `sprite proxy PORT`
 
 ### Network Access

--- a/src/content/docs/reference/configuration.mdx
+++ b/src/content/docs/reference/configuration.mdx
@@ -209,7 +209,7 @@ The default Sprite environment includes:
 
 No default ports are exposed. Start services on any port and access via:
 
-1. **Sprite URL** - `https://sprite-name.sprites.dev:PORT`
+1. **Sprite URL** - `https://sprite-name.sprites.app:PORT`
 2. **Port forwarding** - `sprite proxy PORT`
 
 ### Network Access

--- a/src/content/docs/working-with-sprites.mdx
+++ b/src/content/docs/working-with-sprites.mdx
@@ -101,7 +101,7 @@ Your Sprite stays awake while there's activity, and sleeps when there isn't. Act
 
 ## Networking: URLs and Port Forwarding
 
-Every Sprite gets a URL: `https://<name>.sprites.app`
+Every Sprite gets a URL: `https://<name>.sprites.dev`
 
 ### HTTP Access
 


### PR DESCRIPTION
The Sprite URL domain is `.sprites.dev` (confirmed against the live rc44 CLI), but two hand-written pages still used the stale `.sprites.app`.

## What changed
- `working-with-sprites.mdx`: URL example in the Networking section.
- `reference/configuration.mdx`: Sprite URL entry under Network Configuration.

## Not touched (generated)
`cli/commands.mdx` and `api/*/sprites.mdx` also contain `.sprites.app`, but they're auto-generated (`scripts/generate-cli-docs`, `generate-api-docs.ts`). The live CLI already emits `.sprites.dev`, so `cli/commands.mdx` corrects itself on the next regen; the API examples need the fix upstream in the schema. Hand-editing generated files would be clobbered, so they're left for a regen pass.