### PR TITLE
Skip draft pages in Lighthouse CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -230,20 +230,34 @@ jobs:
               pull_number: context.issue.number,
             });
 
+            const fs = require('fs');
             const baseUrl = '${{ needs.preview.outputs.url }}';
             const urls = new Set([baseUrl]); // Always test homepage
 
             for (const file of files) {
               // Match .mdx files in src/content/docs/
               const match = file.filename.match(/^src\/content\/docs\/(.+)\.mdx$/);
-              if (match && file.status !== 'removed') {
-                let path = match[1];
-                // index.mdx maps to root, others map to their path
-                if (path === 'index') {
-                  urls.add(baseUrl);
-                } else {
-                  urls.add(`${baseUrl}/${path}/`);
+              if (!match || file.status === 'removed') continue;
+
+              // Skip draft pages. They're excluded from the production build,
+              // so their URLs 404 on the preview deploy and fail Lighthouse.
+              try {
+                const source = fs.readFileSync(file.filename, 'utf8');
+                const frontmatter = source.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+                if (frontmatter && /^draft:\s*true\s*$/m.test(frontmatter[1])) {
+                  console.log(`Skipping draft page: ${file.filename}`);
+                  continue;
                 }
+              } catch {
+                // If the file can't be read, fall through and test it anyway.
+              }
+
+              let path = match[1];
+              // index.mdx maps to root, others map to their path
+              if (path === 'index') {
+                urls.add(baseUrl);
+              } else {
+                urls.add(`${baseUrl}/${path}/`);
               }
             }
 


### PR DESCRIPTION
## Problem
The Lighthouse job builds its URL list from every `.mdx` a PR changes, without checking whether the page is a draft. Draft pages (`draft: true`) are excluded from the production build, so their URLs 404 on the preview deploy and Lighthouse fails the run with `ERRORED_DOCUMENT_REQUEST (Status code: 404)`.

This bit PR #205, which edited the draft `reference/configuration.mdx` and failed Lighthouse on `/reference/configuration/` even though the change was fine.

## Fix
In the "Get changed pages" step, read each changed file's frontmatter (the PR head is already checked out) and skip any page with `draft: true` before adding its URL. Unreadable files fall through and are still tested, so nothing is silently dropped.

Verified locally: `draft: true` pages are skipped, published pages are still tested, and the workflow YAML still parses.