### PR TITLE
Default to light theme for first-time visitors

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -50,7 +50,7 @@ Custom Starlight components in `src/components/` override defaults: `Head.astro`
 ## Styling Notes
 
 - Theme uses rounded corners (`--radius: 0.5rem`)
-- Dark mode is default; light mode uses violet accent (hue 285), dark uses teal/green (hue ~145)
+- Light mode is default; light mode uses violet accent (hue 285), dark uses teal/green (hue ~145)
 - Tailwind v4 custom variant: `@custom-variant dark (&:is(.dark *, [data-theme="dark"] *))`
 - Tables are auto-styled via rehype plugin with `data-slot` attributes for CSS targeting
 

--- a/src/components/ThemeProvider.astro
+++ b/src/components/ThemeProvider.astro
@@ -1,5 +1,5 @@
 ---
-// Custom ThemeProvider that defaults to dark instead of system preference
+// Custom ThemeProvider that defaults to light instead of system preference
 ---
 
 {/* This is intentionally inlined to avoid FOUC. */}
@@ -7,12 +7,12 @@
 	window.StarlightThemeProvider = (() => {
 		const storedTheme =
 			typeof localStorage !== 'undefined' ? localStorage.getItem('starlight-theme') : null;
-		// null = never set any preference → default to dark
+		// null = never set any preference → default to light
 		// '' (empty string) = user chose 'auto' → use system preference
 		// 'light'/'dark' = user chose explicitly
 		let theme;
 		if (storedTheme === null) {
-			theme = 'dark';
+			theme = 'light';
 		} else if (storedTheme === '') {
 			theme = window.matchMedia('(prefers-color-scheme: light)').matches ? 'light' : 'dark';
 		} else {

--- a/src/components/react/ThemeSwitcher.tsx
+++ b/src/components/react/ThemeSwitcher.tsx
@@ -27,7 +27,7 @@ function getTheme(): Theme {
       return stored === '' ? 'auto' : stored;
     }
   }
-  return 'dark';
+  return 'light';
 }
 
 function setTheme(theme: Theme) {


### PR DESCRIPTION
Right now the docs force dark mode on anyone who's never touched the theme picker. This flips that default to light, in keeping with bringing Sprites under Fly.io branding.

Everything else works the same: picking light or dark explicitly still sticks, and "auto" still follows your system preference. Folks who already chose a theme keep their choice, since it's stored in localStorage.

Also updates the CLAUDE.md styling note to match our change.