### PR TITLE
Regenerate CLI docs and bump API reference to v0.0.1-rc48

### DIFF
--- a/scripts/generate-cli-docs/help-parser.ts
+++ b/scripts/generate-cli-docs/help-parser.ts
@@ -72,10 +72,17 @@ export function parseHelpOutput(command: string, output: string): ParsedHelp {
     // Parse content based on current section
     switch (currentSection) {
       case 'usage':
-        if (trimmedLine && !result.usage) {
+        // A blank line ends the usage block; anything after it belongs to
+        // another section (Flags, Examples, or free-form prose we don't use).
+        if (!trimmedLine) {
+          if (result.usage) {
+            currentSection = 'none';
+          }
+        } else if (!result.usage) {
           result.usage = trimmedLine;
-        } else if (trimmedLine) {
-          result.usage += ` ${trimmedLine}`;
+        } else {
+          // Commands can document several invocation forms, one per line.
+          result.usage += `\n${trimmedLine}`;
         }
         break;
 
@@ -118,12 +125,18 @@ function parseOptionLine(
   currentOption: Partial<ParsedOption> | null,
   setCurrentOption: (opt: Partial<ParsedOption> | null) => void,
 ): void {
+  // Arguments are always written as placeholders (`<name>`, `<[host]:port>`),
+  // so anything else after the flag is the start of its description.
+  const ARGUMENT = '(<[^>]*>|\\[[^\\]]*\\])';
+
   // Check if this is a new option (starts with -)
   const optionMatch = trimmedLine.match(
-    /^(-\w)(?:,\s*|\s+)(--[\w-]+)?(?:\s+(\S+))?(?:\s+(.+))?$/,
+    new RegExp(
+      `^(-\\w)(?:,\\s*|\\s+)(--[\\w-]+)?(?:\\s+${ARGUMENT})?(?:\\s+(.+))?$`,
+    ),
   );
   const longOnlyMatch = trimmedLine.match(
-    /^(--[\w-]+)(?:\s+(\S+))?(?:\s+(.+))?$/,
+    new RegExp(`^(--[\\w-]+)(?:\\s+${ARGUMENT})?(?:\\s+(.+))?$`),
   );
   const goStyleMatch = trimmedLine.match(/^-(\w+)(?:\s+(\w+))?$/);
 

--- a/scripts/generate-cli-docs/index.ts
+++ b/scripts/generate-cli-docs/index.ts
@@ -235,7 +235,7 @@ async function main(): Promise<void> {
     );
 
     // Step 9: Write output
-    writeFileSync(config.outputPath, mdxContent);
+    writeFileSync(config.outputPath, `${mdxContent}\n`);
     console.log(`  Written to: ${config.outputPath}`);
 
     // Step 10: Print report

--- a/src/content/docs/cli/commands.mdx
+++ b/src/content/docs/cli/commands.mdx
@@ -24,7 +24,7 @@ sprite login [flags] [api-url]
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -45,7 +45,7 @@ sprite logout [flags]
 ```
 
 **Options:**
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -57,14 +57,14 @@ sprite logout
 sprite org auth - Add an API token
 
 ```bash
-sprite org auth [-o <api>:<org>] [api-url|alias] Arguments: api-url|alias          Optional API endpoint URL or alias (default: https://api.sprites.dev)
+sprite org auth [-o <api>:<org>] [api-url|alias]
 ```
 
 **Aliases:** `sprite orgs`, `sprite organizations`, `sprite o`
 
 **Options:**
 - `-o, --org <name>` - Specify organization
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -81,11 +81,11 @@ sprite org auth https://staging-api.sprites.dev -o staging:test-org
 sprite org list - Show configured tokens
 
 ```bash
-sprite org list [api-url|alias] Arguments: api-url|alias          Optional filter by API endpoint URL or alias
+sprite org list [api-url|alias]
 ```
 
 **Options:**
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 ### `sprite org logout`
 
@@ -96,8 +96,8 @@ sprite org logout [flags]
 ```
 
 **Options:**
-- `--force Skip` - confirmation prompt
-- `-h, --help Show` - this help message
+- `--force` - Skip confirmation prompt
+- `-h, --help` - Show this help message
 
 ### `sprite org keyring disable`
 
@@ -108,7 +108,7 @@ sprite org keyring disable
 ```
 
 **Options:**
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -124,7 +124,7 @@ sprite org keyring enable
 ```
 
 **Options:**
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 ### `sprite auth setup`
 
@@ -136,7 +136,7 @@ sprite auth setup --token <token>
 
 **Options:**
 - `--token <token>` - Token in format: org-slug/org-id/token-id/token-value
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -156,9 +156,9 @@ sprite create [flags] [sprite-name]
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `--skip-console Exit` - after creating instead of connecting to console
+- `--skip-console` - Exit after creating instead of connecting to console
 - `--label <label>` - Label to apply to the sprite (can be repeated)
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 > Creates a new sprite with the specified name.
 > The sprite will be created in the selected organization.
@@ -190,8 +190,8 @@ sprite use [flags] [sprite-name]
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `--unset Remove` - the .sprite file from current directory
-- `-h, --help Show` - this help message
+- `--unset` - Remove the .sprite file from current directory
+- `-h, --help` - Show this help message
 
 > Creates a .sprite file in the current directory to set the active sprite.
 > This file will be used by other commands when no sprite is explicitly specified.
@@ -218,9 +218,9 @@ sprite list [flags]
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `-w, --watch Watch` - for live updates
+- `-w, --watch` - Watch for live updates
 - `--prefix <prefix>` - Filter sprites by name prefix
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 > Lists all sprites in the selected organization.
 > Use --prefix to filter sprites by name prefix.
@@ -243,8 +243,8 @@ sprite destroy [flags] [sprite-name]
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `--force Skip` - confirmation prompt
-- `-h, --help Show` - this help message
+- `--force` - Skip confirmation prompt
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -273,12 +273,12 @@ sprite exec [flags] -- <command> [args...]
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
 - `--dir <path>` - Working directory for command
-- `--tty Allocate` - pseudo-TTY
+- `--tty` - Allocate pseudo-TTY
 - `--env <vars>` - Environment variables (KEY=value,KEY2=value2)
-- `--http-post Use` - HTTP/1.1 POST instead of WebSockets (non-TTY only)
-- `--no-port-forward Disable` - automatic local port forwarding for ports opened by the command
+- `--http-post` - Use HTTP/1.1 POST instead of WebSockets (non-TTY only)
+- `--no-port-forward` - Disable automatic local port forwarding for ports opened by the command
 - `--file <source:dest>` - Upload file before exec (repeatable)
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 > When using --tty, terminal environment variables (TERM, COLORTERM, LANG,
 > LC_ALL) are automatically passed through from your local environment.
@@ -306,8 +306,8 @@ sprite console [flags]
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `--no-port-forward Disable` - automatic local port forwarding for ports opened by the console
-- `-h, --help Show` - this help message
+- `--no-port-forward` - Disable automatic local port forwarding for ports opened by the console
+- `-h, --help` - Show this help message
 
 > Opens an interactive shell with a TTY allocated.
 > Uses shell environment variables to determine which shell to use.
@@ -339,7 +339,7 @@ sprite checkpoint create [flags]
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
 - `--comment <text>` - Optional comment describing this checkpoint
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 ### `sprite checkpoint list`
 
@@ -355,8 +355,8 @@ sprite checkpoint list [flags]
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
 - `--history <version>` - Filter by history version
-- `--include-auto Include` - auto-generated checkpoints
-- `-h, --help Show` - this help message
+- `--include-auto` - Include auto-generated checkpoints
+- `-h, --help` - Show this help message
 
 ### `sprite checkpoint info`
 
@@ -369,7 +369,7 @@ sprite checkpoint info [flags] <version-id>
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -389,7 +389,7 @@ sprite checkpoint delete [flags] <version-id>
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -409,7 +409,7 @@ sprite restore [flags] <version-id>
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -430,13 +430,15 @@ sprite proxy - Forward local ports through the remote server proxy
 
 ```bash
 sprite proxy [flags] <port1> [port2] ... or <local1:remote1> [local2:remote2] ...
+sprite proxy --ssh
 ```
 
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
 - `-W, --stdio <[host]:port>` - Forward stdin and stdout to host:port on the Sprite
-- `-h, --help Show` - this help message
+- `--ssh` - Emulate an SSH session with a Sprite over stdio, for use as an ssh ProxyCommand.
+- `-h, --help` - Show this help message
 
 > Each port will be forwarded from localhost to the remote environment.
 > Use LOCAL:REMOTE syntax to map different local and remote ports.
@@ -454,6 +456,7 @@ sprite proxy 4005:4000
 sprite proxy 3001:3000 8081:8080
 sprite proxy -W :22
 sprite proxy -o myorg -s mysprite 8080
+sprite proxy --ssh -s mysprite
 ```
 
 ### `sprite url`
@@ -461,13 +464,14 @@ sprite proxy -o myorg -s mysprite 8080
 sprite url - Manage sprite URL settings
 
 ```bash
-sprite url                  Show sprite URL and auth setting sprite url update [flags]   Update URL authentication settings URL Format: https://<sprite-name>-<org>.sprites.app/ Authentication Modes: sprite     Allows access via browser to Sprite org members, and via org tokens (default) public     No authentication - anyone with URL can access Subcommands: update     Update URL authentication settings
+sprite url                  Show sprite URL and auth setting
+sprite url update [flags]   Update URL authentication settings
 ```
 
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 - `--auth <type>` - Authentication type: 'public' or 'sprite'
 
 **Examples:**
@@ -490,14 +494,14 @@ Security Notes:
 sprite url update - Update URL authentication settings
 
 ```bash
-sprite url update --auth <type> [flags] Authentication Types: sprite     Require org membership to access (default) public     No authentication - anyone with URL can access
+sprite url update --auth <type> [flags]
 ```
 
 **Options:**
 - `-o, --org <name>` - Specify organization
 - `-s, --sprite <name>` - Specify sprite
 - `-a, --auth <type>` - Authentication type: 'public' or 'sprite'
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash
@@ -525,11 +529,11 @@ sprite upgrade [flags]
 ```
 
 **Options:**
-- `--check Check` - for updates without installing
-- `--force Force` - upgrade even if already up to date
+- `--check` - Check for updates without installing
+- `--force` - Force upgrade even if already up to date
 - `--version <version>` - Upgrade to a specific version
 - `--channel <channel>` - Release channel (release, rc, dev)
-- `-h, --help Show` - this help message
+- `-h, --help` - Show this help message
 
 **Examples:**
 ```bash

--- a/src/lib/api-versions.ts
+++ b/src/lib/api-versions.ts
@@ -18,9 +18,9 @@ export interface APIVersion {
 
 export const API_VERSIONS: APIVersion[] = [
   {
-    id: 'v0.0.1-rc46',
-    label: 'v0.0.1-rc46',
-    schemaUrl: 'https://sprites-binaries.t3.storage.dev/api/v0.0.1-rc46',
+    id: 'v0.0.1-rc48',
+    label: 'v0.0.1-rc48',
+    schemaUrl: 'https://sprites-binaries.t3.storage.dev/api/v0.0.1-rc48',
     isLatest: true,
     badge: 'stable',
   },


### PR DESCRIPTION
Routine refresh of the CLI reference and the API version selector.

## CLI docs

Regenerated `src/content/docs/cli/commands.mdx` against the current CLI. The only new surface is **`sprite proxy --ssh`** — emulates an SSH session over stdio for use as an ssh `ProxyCommand`.

Getting that line to render correctly meant fixing three bugs in `scripts/generate-cli-docs/help-parser.ts`, which is where most of the diff comes from:

**Usage blocks now stop at the first blank line, and keep one invocation form per line.** Previously every subsequent line was joined with a space, so `sprite url` rendered as one run-on line inside a code fence:

```
- sprite url                  Show sprite URL and auth setting sprite url update [flags]   Update URL authentication settings URL Format: https://<sprite-name>-<org>.sprites.app/ Authentication Modes: sprite     Allows access via browser to …
+ sprite url                  Show sprite URL and auth setting
+ sprite url update [flags]   Update URL authentication settings
```

`sprite proxy` had the same problem and would have advertised a command that doesn't exist.

**Flag arguments are only recognised in placeholder form** (`<name>`, `<[host]:port>`). The old pattern grabbed the first word of the description instead, which is why every command listed `` `-h, --help Show` - this help message ``. That accounts for the repeated one-line changes throughout the file:

```
- - `--ssh Emulate` - an SSH session with a Sprite over stdio, for use as an ssh ProxyCommand.
+ - `--ssh` - Emulate an SSH session with a Sprite over stdio, for use as an ssh ProxyCommand.
```

**The generator writes a trailing newline**, so regenerating no longer produces a `\ No newline at end of file` diff.

## API reference

`src/lib/api-versions.ts` moves to `v0.0.1-rc48`. I diffed the rc46 and rc48 schemas — endpoints, types, enums, and websocket messages are identical; only the `version` and `generated` stamps changed. So this is a label bump, and the generated pages are unchanged apart from version strings. Same shape as #214.

## Verification

- `pnpm build` — clean, emits `/api/v001-rc48/*`
- `pnpm test:e2e` — 29/29 passing
- `pnpm lint` — clean

## Note for reviewers

Worth knowing, not fixed here: the CLI has moved off `v0.0.1-rcNN` versioning onto date-based releases (the current binary reports `2026-08-14`), and `rc`/`dev` channels no longer resolve — `release` is the only channel left. The API schema still uses `rcNN`, hence rc48 above. `cli/installation.mdx` documents `sprite upgrade --channel rc`, which now errors with `no such channel: rc`; that needs a follow-up once the CLI versioning story settles.

Also pre-existing and left alone: the generator's `parseMainHelp` looks for a `Global Options:` header but the CLI prints `Global Flags:`, so the global-options section of the page has been empty for a while. Easy follow-up if we want `--debug` documented.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PaigmfRkf95qHh1T2FxdP8